### PR TITLE
You can't use bootstrap-sass without sass-rails, so you need to require i

### DIFF
--- a/lib/bootstrap-sass.rb
+++ b/lib/bootstrap-sass.rb
@@ -1,3 +1,5 @@
+require 'sass-rails'
+
 module Bootstrap
   module Rails
     class Engine < ::Rails::Engine


### PR DESCRIPTION
You can't use bootstrap-sass without sass-rails, so you need to require it (gemspec dependency are not automatically required). When used from an engine, this ended up in weird races conditions when sass-rails wasn't present in main_app's Gemfile (which requires it by default).

Should fix https://github.com/sferik/rails_admin/issues/759
