### PR TITLE
Fix select box height

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/forms.css.scss
+++ b/vendor/assets/stylesheets/bootstrap/forms.css.scss
@@ -100,7 +100,7 @@ input[type=button], input[type=reset], input[type=submit] {
 
 select, input[type=file] {
   height: $baseline * 1.5; // In IE7, the height of the select element cannot be changed by height, only font-size
-  height: auto; // reset for IE7. bah.
+  *height: auto; // reset for IE7. bah.
   line-height: $baseline * 1.5;
   *margin-top: 4px; /* For IE7, add top margin to align select with labels */
 }


### PR DESCRIPTION
Styling on select boxes is not the same as it is in bootstrap proper. The so-called "star hack" was improperly implemented (missing the *) in the sass port.

See the [less source](https://github.com/twitter/bootstrap/blob/master/lib/forms.less#L115)
