### PR TITLE
Fix condensed-table padding

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/tables.css.scss
+++ b/vendor/assets/stylesheets/bootstrap/tables.css.scss
@@ -36,7 +36,7 @@ table {
 
 // Condensed table
 .condensed-table {
-  .th, .td {
+  th, td {
     padding: 5px 5px 4px;
   }
 }


### PR DESCRIPTION
The condensed-table class wasn't working properly, looks like the tag selectors were changed to class selectors.
