### PR TITLE
Tiny change to make it easy to override variables.

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/variables.css.scss
+++ b/vendor/assets/stylesheets/bootstrap/variables.css.scss
@@ -3,49 +3,49 @@
  * ----------------------------------------------------- */
 
 // Links
-$linkColor:         #0069d6;
-$linkColorHover:    darken($linkColor, 15);
+$linkColor:         #0069d6 !default;
+$linkColorHover:    darken($linkColor, 15) !default;
 
 // Grays
-$black:             #000;
-$grayDark:          lighten($black, 25%);
-$gray:              lighten($black, 50%);
-$grayLight:         lighten($black, 75%);
-$grayLighter:       lighten($black, 90%);
-$white:             #fff;
+$black:             #000 !default;
+$grayDark:          lighten($black, 25%) !default;
+$gray:              lighten($black, 50%) !default;
+$grayLight:         lighten($black, 75%) !default;
+$grayLighter:       lighten($black, 90%) !default;
+$white:             #fff !default;
 
 // Accent Colors
-$blue:              #049CDB;
-$blueDark:          #0064CD;
-$green:             #46a546;
-$red:               #9d261d;
-$yellow:            #ffc40d;
-$orange:            #f89406;
-$pink:              #c3325f;
-$purple:            #7a43b6;
+$blue:              #049CDB !default;
+$blueDark:          #0064CD !default;
+$green:             #46a546 !default;
+$red:               #9d261d !default;
+$yellow:            #ffc40d !default;
+$orange:            #f89406 !default;
+$pink:              #c3325f !default;
+$purple:            #7a43b6 !default;
 
 // Baseline grid
-$basefont:          13px;
-$baseline:          18px;
+$basefont:          13px !default;
+$baseline:          18px !default;
 
 // Griditude
 // Modify the grid styles in mixins.less
-$gridColumns:       16;
-$gridColumnWidth:   40px;
-$gridGutterWidth:   20px;
-$extraSpace:        ($gridGutterWidth * 2); // For our grid calculations
-$siteWidth:         ($gridColumns * $gridColumnWidth) + ($gridGutterWidth * ($gridColumns - 1));
+$gridColumns:       16 !default;
+$gridColumnWidth:   40px !default;
+$gridGutterWidth:   20px !default;
+$extraSpace:        ($gridGutterWidth * 2) !default; // For our grid calculations
+$siteWidth:         ($gridColumns * $gridColumnWidth) + ($gridGutterWidth * ($gridColumns - 1)) !default;
 
 // Color Scheme
 // Use this to roll your own color schemes if you like (unused by Bootstrap by default)
-$baseColor:         $blue;                  // Set a base color
-$complement:        spin($baseColor, 180);  // Determine a complementary color
-$split1:            spin($baseColor, 158);  // Split complements
-$split2:            spin($baseColor, -158);
-$triad1:            spin($baseColor, 135);  // Triads colors
-$triad2:            spin($baseColor, -135);
-$tetra1:            spin($baseColor, 90);   // Tetra colors
-$tetra2:            spin($baseColor, -90);
-$analog1:           spin($baseColor, 22);   // Analogs colors
-$analog2:           spin($baseColor, -22);
+$baseColor:         $blue !default;                  // Set a base color
+$complement:        spin($baseColor, 180) !default;  // Determine a complementary color
+$split1:            spin($baseColor, 158) !default;  // Split complements
+$split2:            spin($baseColor, -158) !default;
+$triad1:            spin($baseColor, 135) !default;  // Triads colors
+$triad2:            spin($baseColor, -135) !default;
+$tetra1:            spin($baseColor, 90) !default;   // Tetra colors
+$tetra2:            spin($baseColor, -90) !default;
+$analog1:           spin($baseColor, 22) !default;   // Analogs colors
+$analog2:           spin($baseColor, -22) !default;
 


### PR DESCRIPTION
Adds '!default' to all variable declarations so we can override them, as done in the
compass port of bootstrap (https://github.com/hecbuma/compass-bootstrap). No need for generators or anything complicated, just set
the variables you want to override before importing bootstrap with
'@import bootstrap'.

Ex.: 
    $gridColumns:       12;
    $gridColumnWidth:   60px;
    $gridGutterWidth:   20px;
    @import "bootstrap";
