### PR TITLE
back off sass-rails specificity

### DIFF
--- a/bootstrap-sass.gemspec
+++ b/bootstrap-sass.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.summary = "Twitter's Bootstrap, converted to SASS and ready to drop into Rails"
   s.homepage = "http://github.com/thomas-mcdonald/bootstrap-sass"
 
-  s.add_dependency 'sass-rails', '~> 3.1.0'
+  s.add_dependency 'sass-rails', '~> 3.1'
 
   s.files = Dir["vendor/**/*.css.scss"] + Dir["vendor/**/*.js"] + ["README.md", "LICENSE", "lib/bootstrap-sass.rb"]
 end


### PR DESCRIPTION
Is there a way to test this against the newer versions of `sass-rails`?
