### PR TITLE
Rails development mode is sensitive to javascript include order

### DIFF
--- a/vendor/assets/javascripts/bootstrap.js
+++ b/vendor/assets/javascripts/bootstrap.js
@@ -1,9 +1,8 @@
 //= require bootstrap-modal
 //= require bootstrap-buttons
-//= require bootstrap-dropdown
 //= require bootstrap-scrollspy
 //= require bootstrap-tabs
+//= require bootstrap-dropdown
 //= require bootstrap-twipsy
 //= require bootstrap-popover
 //= require bootstrap-alerts
-


### PR DESCRIPTION
When running in Rails in development mode the dropdowns for the navigation bar weren't working (in production mode they were fine), changing the order in which the javascript files are loaded solves this issue. I've changed it and humbly offer you my pull request :)
