### PR TITLE
2.0: "border-radius: 0 \0/" breaks Sass and Rails asset compilation

### DIFF
--- a/bootstrap-sass.gemspec
+++ b/bootstrap-sass.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/thomas-mcdonald/bootstrap-sass"
 
   s.add_development_dependency 'compass'
-  s.add_development_dependency 'sass-rails', '~> 3.2.3'
+  s.add_development_dependency 'sass-rails', '~> 3.1'
 
   s.files = Dir["vendor/**/*.{scss,js,png}"] + Dir["lib/**/*"] + Dir["templates/**/*"] + ["README.md", "LICENSE"]
 end


### PR DESCRIPTION
Referencing the discussion here: https://github.com/twitter/bootstrap/issues/1394  I was also receiving the
"border-radius: 0 \0/" breaks Sass and Rails asset compilation" problem.

The SASS method of interpolation to escape the \0/ that you implemented on line 78 of the _forms.scss was still giving me problems in my Rails3.2 app. I changed the border radius to GMFlash's suggestion and it fixed it for me.
