### PR TITLE
Use image-url convenience method instead of asset-url

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_sprites.scss
+++ b/vendor/assets/stylesheets/bootstrap/_sprites.scss
@@ -19,14 +19,14 @@
   width: 14px;
   height: 14px;
   vertical-align: text-top;
-  background-image: asset-url("glyphicons-halflings.png", image);
+  background-image: image-url("glyphicons-halflings.png");
   background-position: 14px 14px;
   background-repeat: no-repeat;
 
   @include ie7-restore-right-whitespace();
 }
 .icon-white {
-  background-image: asset-url("glyphicons-halflings-white.png", image);
+  background-image: image-url("glyphicons-halflings-white.png");
 }
 
 .icon-glass              { background-position: 0      0; }


### PR DESCRIPTION
For some reason, when using bootstrap-sass with <a href="https://github.com/welaika/wordless">Wordless</a>, image-url seems to work when asset-url doesn't, but I'm not sure why. Could you switch to using image-url("img.png") instead of asset-url("img.png", image)? Would changing this interfere with anything else?
