### PR TITLE
Update to include the current javascript code included for the button data-...

### DIFF
--- a/vendor/assets/javascripts/bootstrap-button.js
+++ b/vendor/assets/javascripts/bootstrap-button.js
@@ -91,7 +91,9 @@
 
   $(function () {
     $('body').on('click.button.data-api', '[data-toggle^=button]', function ( e ) {
-      $(e.currentTarget).button('toggle')
+      var $btn = $(e.target)
+      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
+      $btn.button('toggle')
     })
   })
 


### PR DESCRIPTION
...api as per 2.0.1 of twitter-bootstrap.

Without this change, I could not get the toggle button groups to work. Strangely the declared version 2.0.1 of the button js code wasn't the same as the code in the vendor javascripts folder.
