### PR TITLE
Compatible with Rails 2.3 and Compass

### DIFF
--- a/lib/bootstrap-sass.rb
+++ b/lib/bootstrap-sass.rb
@@ -3,7 +3,7 @@ module Bootstrap
 
   # Inspired by Kaminari
   def self.load!
-    if rails?
+    if rails_asset_pipeline?
       require 'sass-rails' # See: https://github.com/thomas-mcdonald/bootstrap-sass/pull/4
       require 'bootstrap-sass/engine'
       require 'bootstrap-sass/config/sass_extentions'
@@ -20,8 +20,8 @@ module Bootstrap
   end
 
   private
-  def self.rails?
-    defined?(::Rails)
+  def self.rails_asset_pipeline?
+    defined?(::Rails) && ::Rails.version >= '3.1.0'
   end
 
   def self.compass?


### PR DESCRIPTION
This patch make it possible for Rails 2.3 to use `bootstrap-sass` via `compass`. I suppose this should also make it work for Rails 3.0, but I didn't verify that.
