### PR TITLE
Typo in gridInputSpan

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -560,7 +560,7 @@
   }
 }
 
-@mixin gridInputSpan($columns, $gridColumWidth, $gridGutterWidth) {
+@mixin gridInputSpan($columns, $gridColumnWidth, $gridGutterWidth) {
   width: (($gridColumnWidth) * $columns) + ($gridGutterWidth * ($columns - 1)) - 10;
 }
 


### PR DESCRIPTION
This typo resulted the miscalculation of form elements' .spanXX widths in responsive layout.
