### PR TITLE
btn:hover doesn't use the btnBackgroundHighlight variable

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_buttons.scss
+++ b/vendor/assets/stylesheets/bootstrap/_buttons.scss
@@ -33,7 +33,7 @@
 .btn:hover {
   color: $grayDark;
   text-decoration: none;
-  background-color: darken($white, 10%);
+  background-color: $btnBackgroundHighlight;
   background-position: 0 -15px;
 
   // transition is only when going to hover, otherwise the background


### PR DESCRIPTION
Overriding the default background color of the default .btn with the btnBackground variables doesn't work because of the darken(white, 10%) value that had been set in btn:hover.
