### PR TITLE
Documentation: how to use Bootstrap mixins with multiple values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Need to configure a variable or two? Simple define the value of the variable you
 
 **Note**: It's important that the file you are importing is not named `bootstrap`, since this will cause an import loop. As a general rule, errors are something you should try to avoid.
 
+##### Passing multiple values to mixins
+
+Some CSS3 properties take multiple values, such as `box-shadow` or `text-shadow`. To pass multiple values to the Bootstrap mixins, you must escape the values or else the Sass parser will choke on the commas. Here's how to escape the values in Sass:
+
+    .selector {
+      @include box-shadow(#{0 2px 5px rgba(0,0,0,.25) inset, 0 -2px 5px rgba(0,0,0,.25) inset});
+    }
+
 #### Javascripts
 
 You can include the Bootstrap javascripts through two methods. In this case, Sprocket's `//= require` directives are useful, since there is no better alternative.


### PR DESCRIPTION
I spend a little too much time googling for this, so I figured others could benefit from having this lil' nugget in the readme.

Essentially, passing multiple values (`box-shadow`s, for instance) as a single parameter to Sass mixins, requires you to escape the values to avoid syntax errors caused by the comma(s). Other frameworks, eg. Compass, takes [a different approach](http://compass-style.org/reference/compass/css3/box_shadow/#mixin-box-shadow), using a fixed number of parameters.

Mark Otto (@markdotto) wrote about his approach using escaped values in LESS and I think it warrants documentation in this project. (The site was down when I wrote this, here's a cached copy for reference: http://webcache.googleusercontent.com/search?q=cache:http://www.markdotto.com/2012/04/05/comma-separated-values-in-less-mixins/)

Again, thanks a bunch for your work on this gem!! :heart:
