### PR TITLE
Removing the .nav class to mimic the original bootstrap rule for dropdowns

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_navbar.scss
+++ b/vendor/assets/stylesheets/bootstrap/_navbar.scss
@@ -88,6 +88,12 @@
   .btn-group .btn {
     margin-top: 0; // then undo the margin here so we don't accidentally double it
   }
+  .btn-group {
+    margin: 0;
+    // Vertically center the button given $navbarHeight
+    $elementHeight: 28px;
+    padding: (($navbarHeight - $elementHeight) / 2 - 1) 5px (($navbarHeight - $elementHeight) / 2);
+  }
 }
 
 // Navbar forms


### PR DESCRIPTION
Removing the .nav class to mimic the original bootstrap rule (see the end of this file):
https://github.com/twitter/bootstrap/blob/master/less/navbar.less

You can also see that there is no .nav in the selector for ".navbar .dropdown-menu" at the beginning of the "Menu position and menu carets" section of this file.

This was causing the the arrow to show up on the wrong side of the dropdown list.  The arrow should show up on the top right of a list that is pulled to the right in a .navbar:
http://twitter.github.com/bootstrap/examples/fluid.html
