### PR TITLE
Fix icons

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_variables.scss
+++ b/vendor/assets/stylesheets/bootstrap/_variables.scss
@@ -124,8 +124,8 @@ $zindexModal:             1050;
 
 // Sprite icons path
 // -------------------------
-$iconSpritePath:          image-url("glyphicons-halflings.png", image) !default;
-$iconWhiteSpritePath:     image-url("glyphicons-halflings-white.png", image) !default;
+$iconSpritePath:          image-url('glyphicons-halflings.png');
+$iconWhiteSpritePath:     image-url('glyphicons-halflings-white.png');
 
 
 // Input placeholder text color


### PR DESCRIPTION
Hey,

Other users commenting on issue #105 are the ones who came up with the idea.

The !default or image option in lines 127 & 128 was causing the sprite url for icons to be formatted in a way that chrome can not handle: 

  "../img/glyphicons-halflings.png"

I do not know if the problem affects other browsers.
Cheers,
