### PR TITLE
move .clearfix style declaration out of _mixins

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -20,7 +20,6 @@
     clear: both;
   }
 }
-.clearfix { @include clearfix(); }
 
 // Webkit-style focus
 // ------------------

--- a/vendor/assets/stylesheets/bootstrap/_utilities.scss
+++ b/vendor/assets/stylesheets/bootstrap/_utilities.scss
@@ -21,3 +21,5 @@
 .invisible {
   visibility: hidden;
 }
+
+.clearfix { @include clearfix(); }


### PR DESCRIPTION
the _mixins.scss file should only have @mixin
declarations and not any actual style declarations.

that way you can @import '_mixins' and have all the mixing
available to you but not have to worry about it spitting out
style rules into you stylesheet that you did not intend.
