### PR TITLE
Change in _forms.scss to allow rounded search field (.search-query it's overwrite by input)

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_forms.scss
+++ b/vendor/assets/stylesheets/bootstrap/_forms.scss
@@ -381,7 +381,7 @@ input:focus:required:invalid, textarea:focus:required:invalid, select:focus:requ
 // SEARCH FORM
 // -----------
 
-.search-query {
+input.search-query { // input. fix the overwriting of the search-query and allow rounded corner for the search field
   padding-right: 14px;
   padding-right: 4px \9;
   padding-left: 14px;


### PR DESCRIPTION
// input. fix the overwriting of the search-query and allow rounded corner for the search field

-.search-query {

+input.search-query { 

  padding-right: 14px;
  padding-right: 4px \9;
  padding-left: 14px;
  padding-left: 4px \9; /\* IE7-8 doesn't have border-radius, so don't indent the padding */
  margin-bottom: 0; // remove the default margin on all inputs
  @include border-radius(14px);
}

This will fix the problem (this is a problem present just in the last v2.0.4).

The change solve the problem adding specificity.
