### PR TITLE
enable arrow key navigation in typeahead for Firefox 

### DIFF
--- a/vendor/assets/javascripts/bootstrap-typeahead.js
+++ b/vendor/assets/javascripts/bootstrap-typeahead.js
@@ -168,7 +168,7 @@
         .on('keypress', $.proxy(this.keypress, this))
         .on('keyup',    $.proxy(this.keyup, this))
 
-      if ($.browser.webkit || $.browser.msie) {
+      if ($.browser.webkit || $.browser.msie || $.browser.mozilla) {
         this.$element.on('keydown', $.proxy(this.keypress, this))
       }
 


### PR DESCRIPTION
According to @fat, in 2.0.3 mozilla was added to the browsers listening for keydown in typeahead, which is not reflected in thomas-mcdonald/bootstrap-sass.

see https://github.com/twitter/bootstrap/issues/3741 for more info
