### PR TITLE
changed zindex variables to use !default like everything else.

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_variables.scss
+++ b/vendor/assets/stylesheets/bootstrap/_variables.scss
@@ -114,12 +114,12 @@ $dropdownDividerBottom: $white !default;
 // -------------------------
 // Used for a bird's eye view of components dependent on the z-axis
 // Try to avoid customizing these :)
-$zindexDropdown:          1000;
-$zindexPopover:           1010;
-$zindexTooltip:           1020;
-$zindexFixedNavbar:       1030;
-$zindexModalBackdrop:     1040;
-$zindexModal:             1050;
+$zindexDropdown:          1000 !default;
+$zindexPopover:           1010 !default;
+$zindexTooltip:           1020 !default;
+$zindexFixedNavbar:       1030 !default;
+$zindexModalBackdrop:     1040 !default;
+$zindexModal:             1050 !default;
 
 
 // Sprite icons path


### PR DESCRIPTION
All variables should be set to use `!default`. Currently z-index related variables are not.

Comments say `// Try to avoid customizing these :)` ... But when you are using external widgets, javascripts, banners, etc you might have to change those to something bigger or smaller.

I'm using something like following and it seem to work ok. It should be possible to change them like any other variables. It's just on your own risk.

```
$zindexDropdown:          2147401000;
$zindexPopover:           2147401010;
$zindexTooltip:           2147401020;
$zindexFixedNavbar:       2147401030;
$zindexModalBackdrop:     2147401040;
$zindexModal:             2147401050;
```
