### PR TITLE
Fix to make data-methods work in dropdown menu

### DIFF
--- a/vendor/assets/javascripts/bootstrap-dropdown.js
+++ b/vendor/assets/javascripts/bootstrap-dropdown.js
@@ -142,7 +142,7 @@
     $('html')
       .on('click.dropdown.data-api touchstart.dropdown.data-api', clearMenus)
     $('body')
-      .on('click.dropdown touchstart.dropdown.data-api', '.dropdown', function (e) { e.stopPropagation() })
+      .on('click.dropdown touchstart.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
       .on('click.dropdown.data-api touchstart.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)
       .on('keydown.dropdown.data-api touchstart.dropdown.data-api', toggle + ', [role=menu]' , Dropdown.prototype.keydown)
   })


### PR DESCRIPTION
Data methods doesn't work in dropdown menus. I.e. if you have a logout link with method: : delete it will still send a GET request. This has been fixed in v2.1.1 (wip) of the original Bootstrap. It's a small .js issue.
