### PR TITLE
Added missing warning style for table row highlighting

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_tables.scss
+++ b/vendor/assets/stylesheets/bootstrap/_tables.scss
@@ -201,4 +201,7 @@ table {
   tbody tr.info td {
     background-color: $infoBackground;
   }
+  tbody tr.warning td {
+    background-color: $warningBackground;
+ }
 }


### PR DESCRIPTION
The warning style was missing for table row highlighting so I have added it.
