### PR TITLE
Missing info state for input warning control-group.

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_forms.scss
+++ b/vendor/assets/stylesheets/bootstrap/_forms.scss
@@ -349,6 +349,10 @@ input[type="checkbox"][readonly] {
 .control-group.success {
   @include formFieldState($successText, $successText, $successBackground);
 }
+// Info
+.control-group.info {
+  @include formFieldState($infoText, $infoText, $infoBackground);
+}
 
 // HTML5 invalid states
 // Shares styles with the .control-group.error above


### PR DESCRIPTION
Addition of missing style which adds the blue "info" highlight for form control-groups.
