### PR TITLE
.input-block-level should also be a class, not just a mixin

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -147,6 +147,7 @@
 // --------------------------------------------------
 
 // Block level inputs
+// This is also a class, defined at the bottom of the file
 @mixin input-block-level() {
   display: block;
   width: 100%;
@@ -631,4 +632,8 @@
 
 @mixin grid-input-span($columns, $columnWidth, $gutterWidth) {
   width: (($columnWidth) * $columns) + ($gutterWidth * ($columns - 1)) - 14;
+}
+
+.input-block-level {
+  @include input-block-level;
 }


### PR DESCRIPTION
In the original bootstrap, .input-block-level is a class and a mixin since it doesn't have parentheses in the definition https://github.com/twitter/bootstrap/blob/master/less/mixins.less#L154. This is needed to preserve that functionality.
