### PR TITLE
[FIX] Compass can't build _forms.css due to invalid character in comment

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_forms.scss
+++ b/vendor/assets/stylesheets/bootstrap/_forms.scss
@@ -210,7 +210,7 @@ input[type="checkbox"]:focus {
 // Placeholder
 // -------------------------
 
-// Placeholder text gets special styles because when browsers invalidate entire lines if it doesn’t understand a selector
+// Placeholder text gets special styles because when browsers invalidate entire lines if it doesn't understand a selector
 input,
 textarea {
   @include placeholder();


### PR DESCRIPTION
Changed one character so compass can build _forms.scss without running into _“Syntax error: Invalid US-ASCII character "\xE2"_ error.
