### PR TITLE
Change #fadein to #fade_in (sass supports only #fade_in or #opacify)

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -397,7 +397,7 @@
   text-shadow: $textShadow;
   @include gradient-vertical($primaryColor, $secondaryColor);
   border-color: $secondaryColor $secondaryColor darken($secondaryColor, 15%);
-  border-color: rgba(0,0,0,.1) rgba(0,0,0,.1) fadein(rgba(0,0,0,.1), 15%);
+  border-color: rgba(0,0,0,.1) rgba(0,0,0,.1) fade_in(rgba(0,0,0,.1), .15);
 }
 
 // Gradients


### PR DESCRIPTION
It seems Sass doesn't support `fadein` method...
It supports [fade_in](http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html#opacify-instance_method), so I changed `fadein` to `fade_in`.

I would really appreciate it if you took a look.
Thanks!
Keiko
