### PR TITLE
Fixed @import "bootstrap" in Rails projects with root stylesheet in subdirectory

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/bootstrap.scss
+++ b/vendor/assets/stylesheets/bootstrap/bootstrap.scss
@@ -9,55 +9,55 @@
  */
 
 // Core variables and mixins
-@import "./variables"; // Modify this for custom colors, font-sizes, etc
-@import "./mixins";
+@import "bootstrap/variables"; // Modify this for custom colors, font-sizes, etc
+@import "bootstrap/mixins";
 
 // CSS Reset
-@import "./reset";
+@import "bootstrap/reset";
 
 // Grid system and page structure
-@import "./scaffolding";
-@import "./grid";
-@import "./layouts";
+@import "bootstrap/scaffolding";
+@import "bootstrap/grid";
+@import "bootstrap/layouts";
 
 // Base CSS
-@import "./type";
-@import "./code";
-@import "./forms";
-@import "./tables";
+@import "bootstrap/type";
+@import "bootstrap/code";
+@import "bootstrap/forms";
+@import "bootstrap/tables";
 
 // Components: common
-@import "./sprites";
-@import "./dropdowns";
-@import "./wells";
-@import "./component-animations";
-@import "./close";
+@import "bootstrap/sprites";
+@import "bootstrap/dropdowns";
+@import "bootstrap/wells";
+@import "bootstrap/component-animations";
+@import "bootstrap/close";
 
 // Components: Buttons & Alerts
-@import "./buttons";
-@import "./button-groups";
-@import "./alerts"; // Note: alerts share common CSS with buttons and thus have styles in buttons
+@import "bootstrap/buttons";
+@import "bootstrap/button-groups";
+@import "bootstrap/alerts"; // Note: alerts share common CSS with buttons and thus have styles in buttons
 
 // Components: Nav
-@import "./navs";
-@import "./navbar";
-@import "./breadcrumbs";
-@import "./pagination";
-@import "./pager";
+@import "bootstrap/navs";
+@import "bootstrap/navbar";
+@import "bootstrap/breadcrumbs";
+@import "bootstrap/pagination";
+@import "bootstrap/pager";
 
 // Components: Popovers
-@import "./modals";
-@import "./tooltip";
-@import "./popovers";
+@import "bootstrap/modals";
+@import "bootstrap/tooltip";
+@import "bootstrap/popovers";
 
 // Components: Misc
-@import "./thumbnails";
-@import "./media";
-@import "./labels-badges";
-@import "./progress-bars";
-@import "./accordion";
-@import "./carousel";
-@import "./hero-unit";
+@import "bootstrap/thumbnails";
+@import "bootstrap/media";
+@import "bootstrap/labels-badges";
+@import "bootstrap/progress-bars";
+@import "bootstrap/accordion";
+@import "bootstrap/carousel";
+@import "bootstrap/hero-unit";
 
 // Utility classes
-@import "./utilities"; // Has to be last to override when necessary
+@import "bootstrap/utilities"; // Has to be last to override when necessary

--- a/vendor/assets/stylesheets/bootstrap/responsive.scss
+++ b/vendor/assets/stylesheets/bootstrap/responsive.scss
@@ -18,31 +18,31 @@
 // -------------------------
 // Required since we compile the responsive stuff separately
 
-@import "./variables"; // Modify this for custom colors, font-sizes, etc
-@import "./mixins";
+@import "bootstrap/variables"; // Modify this for custom colors, font-sizes, etc
+@import "bootstrap/mixins";
 
 
 // RESPONSIVE CLASSES
 // ------------------
 
-@import "./responsive-utilities";
+@import "bootstrap/responsive-utilities";
 
 
 // MEDIA QUERIES
 // ------------------
 
 // Large desktops
-@import "./responsive-1200px-min";
+@import "bootstrap/responsive-1200px-min";
 
 // Tablets to regular desktops
-@import "./responsive-768px-979px";
+@import "bootstrap/responsive-768px-979px";
 
 // Phones to portrait tablets and narrow desktops
-@import "./responsive-767px-max";
+@import "bootstrap/responsive-767px-max";
 
 
 // RESPONSIVE NAVBAR
 // ------------------
 
 // From 979px and below, show a button to toggle navbar contents
-@import "./responsive-navbar";
+@import "bootstrap/responsive-navbar";


### PR DESCRIPTION
@import "bootstrap" works fine in stylesheets placed directly inside app/assets/stylesheets directory. However, it breaks for files placed in a subdirectory under app/assets/stylesheets with the following error.

```
ActionView::Template::Error (File to import not found or unreadable: variables.
```

This was working correctly in the previous gem release. It seems that a couple of files were moved around.

To fix the incorrect behavior, I changed bootstrap.scss and responsive.scss to use relative paths in @import statements.
