### PR TITLE
Add Sass.load_paths entry to help our absolute @import paths

### DIFF
--- a/lib/bootstrap-sass.rb
+++ b/lib/bootstrap-sass.rb
@@ -17,6 +17,8 @@ module Bootstrap
     else
       raise Bootstrap::FrameworkNotFound, "bootstrap-sass requires either Rails > 3.1 or Compass, neither of which are loaded"
     end
+    stylesheets = File.expand_path(File.join("..", 'vendor', 'assets', 'stylesheets'))
+    Sass.load_paths << stylesheets
   end
 
   private


### PR DESCRIPTION
Add a global `Sass.load_paths` entry for our load path. This should make our @imports rock solid on any Sass 3.2+ installation. Nice feature added in Sass 2.3 - see nex3/sass@5c93cbfe - based on a similar issue and request by a gem, nex3/sass#131

This should resolve thomas-mcdonald/bootstrap-sass#259 better than making users manually adding a load_paths entry, and prevent issues in the future.
