### PR TITLE
Added license to gemspec

### DIFF
--- a/bootstrap-sass.gemspec
+++ b/bootstrap-sass.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.email = 'tom@conceptcoding.co.uk'
   s.summary = "Twitter's Bootstrap, converted to Sass and ready to drop into Rails or Compass"
   s.homepage = "http://github.com/thomas-mcdonald/bootstrap-sass"
+  s.license = "Apache 2.0"
 
   s.add_development_dependency 'compass'
   s.add_development_dependency 'sass-rails', '~> 3.2'


### PR DESCRIPTION
I have been collecting a list of licenses for a project I'm working on using [LicenceFinder](https://github.com/pivotal/LicenseFinder) and I noticed that bootstrap-sass doesn't include a license in it's gemspec. This is a small change which adds that in.
