### PR TITLE
Checking for asset pipeline

### DIFF
--- a/lib/bootstrap-sass.rb
+++ b/lib/bootstrap-sass.rb
@@ -21,7 +21,7 @@ module Bootstrap
 
   private
   def self.asset_pipeline?
-    defined?(::Rails) && ::Rails.version >= '3.1.0'
+    defined?(::Sprockets)
   end
 
   def self.compass?


### PR DESCRIPTION
In some cases asset pipeline (sprockets) used in Rails 3.0 and current checking for Rails version doesn't work.
Probably it's better to check for Sprockets definition. I'm using this fix in my project with Rails 3.0.
