### PR TITLE
Added  Events(open_before and open_after) to Dropdown javascript

### DIFF
--- a/vendor/assets/javascripts/bootstrap-dropdown.js
+++ b/vendor/assets/javascripts/bootstrap-dropdown.js
@@ -52,7 +52,9 @@
       clearMenus()
 
       if (!isActive) {
+        $this.trigger('open_before')
         $parent.toggleClass('open')
+        $this.trigger('open_after')
       }
 
       $this.focus()


### PR DESCRIPTION
A very minor change to add two events to Dropdown javascript. A solution like this has been asked for a number of people on stackoverflow.
http://stackoverflow.com/questions/836694/jquery-adding-change-event-to-dropdown  

These two events are triggered on the open action and differ on whether they occur before or after _toggling the parent class to "open"_ 
