### PR TITLE
Update $dropdownLinkColorActive in _variables.scss

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_variables.scss
+++ b/vendor/assets/stylesheets/bootstrap/_variables.scss
@@ -126,7 +126,7 @@ $dropdownDividerBottom:         $white !default;
 
 $dropdownLinkColor:             $grayDark !default;
 $dropdownLinkColorHover:        $white !default;
-$dropdownLinkColorActive:       $dropdownLinkColor !default;
+$dropdownLinkColorActive:       $white !default;
 
 $dropdownLinkBackgroundActive:  $linkColor !default;
 $dropdownLinkBackgroundHover:   $dropdownLinkBackgroundActive !default;


### PR DESCRIPTION
Update $dropdownLinkColorActive from $dropdownLinkColor to $white.
Fixes Issue 282.

Reference Issue:
https://github.com/thomas-mcdonald/bootstrap-sass/issues/282
