### PR TITLE
Fix namespace Sass module due to conflict with bootstra-sass-rails

### DIFF
--- a/lib/bootstrap-sass.rb
+++ b/lib/bootstrap-sass.rb
@@ -18,7 +18,7 @@ module Bootstrap
       raise Bootstrap::FrameworkNotFound, "bootstrap-sass requires either Rails > 3.1 or Compass, neither of which are loaded"
     end
     stylesheets = File.expand_path(File.join("..", 'vendor', 'assets', 'stylesheets'))
-    Sass.load_paths << stylesheets
+    ::Sass.load_paths << stylesheets
   end
 
   private


### PR DESCRIPTION
No one should really use the two together, but in case they do, or in case any other library defines a Bootstrap::Sass module, we should be clear that we mean the global core Sass module here.

Fixes thomas-mcdonald/bootstrap-sass#293
