### PR TITLE
Fixing :focus state on buttons

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -244,7 +244,7 @@
 }
 
 // Drop shadows
-@mixin box-shadow($shadow...) { 
+@mixin box-shadow($shadow...) {
   -webkit-box-shadow: $shadow;
      -moz-box-shadow: $shadow;
           box-shadow: $shadow;
@@ -499,7 +499,7 @@
   @include reset-filter();
 
   // in these cases the gradient won't cover the background, so we override
-  &:hover, &:active, &.active, &.disabled, &[disabled] {
+  &:hover, &:focus, &:active, &.active, &.disabled, &[disabled] {
     color: $textColor;
     background-color: $endColor;
     *background-color: darken($endColor, 5%);


### PR DESCRIPTION
&:focus is missing in _mixins.css.scss in button background mixin (line 502), so buttons looks broken in :focus state.

![](https://f.cloud.github.com/assets/419747/164024/203ce3ee-786f-11e2-9580-6167bf878cc0.png)

refs jlong/sass-twitter-bootstrap#55
