### PR TITLE
Update lib/bootstrap-sass/engine.rb

### DIFF
--- a/lib/bootstrap-sass/engine.rb
+++ b/lib/bootstrap-sass/engine.rb
@@ -1,7 +1,9 @@
-module Bootstrap
-  module Rails
-    class Engine < ::Rails::Engine
-      # Rails, will you please look in our vendor? kthx
+if defined?(Rails) #Conditional check if the gem is used without Rails
+  module Bootstrap
+    module Rails
+      class Engine < ::Rails::Engine
+        # Rails, will you please look in our vendor? kthx
+      end
     end
   end
 end


### PR DESCRIPTION
When trying to use with non-rails app like sinatra, 
this blows out with undefined constant Rails
