### PR TITLE
#316 - Found a temporary solution, adding it to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Enjoy.
 
 ## Usage
 
+### Rails 4
+
+Due to a change in Rails that prevents images from being compiled in vendor and lib, you'll need to add the following line to your application.rb:
+
+    config.assets.precompile += %w(*.png *.jpg *.jpeg *.gif)
+
 ### Rails
 
 In your Gemfile:


### PR DESCRIPTION
Rails 4 changes asset pipeline slightly so images in lib and vendor won't be precompiled. I don't know what's the point of this change but anyways...

For more info see: https://github.com/rails/rails/pull/9317
