### PR TITLE
Fix the Sprockets context reference for pre-2.10 Sprockets

### DIFF
--- a/lib/bootstrap-sass/compass_functions.rb
+++ b/lib/bootstrap-sass/compass_functions.rb
@@ -18,7 +18,7 @@ module Sass::Script::Functions
       options[:sprockets][:context]
     else
       # Compatibility with sprockets pre 2.10.0
-      options[:custom][:sprockets_context]
+      options[:importer].context
     end
   end
 end


### PR DESCRIPTION
Fixes #366

Fallback to old method of accessing the context object, and use the correct access method through the `:importer` key of the `options` hash, which is set on the context by Sass. The context is passed into the Engine (which is a Tilt::Template) and used as the _scope_ of the render method (see here: https://github.com/rtomayko/tilt/blob/master/lib/tilt/template.rb#L92) , which calls `evaluate(scope...)`. This is how the Sass engine gets access to the options hash to begin with, and how the options hash has the scope of the Context.

If you want to follow, look for how Engines are defined in Sprockets `sprockets.rb`, file types have engines defined by extension in `asset_attributes.rb`, which are then called in `context.rb` -- https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/context.rb#L194 (that's where the scope is passed into the engine, and the context passed with it). The `importer` is added to the options hash when the import is parsed, by the `Sass::Importers::Filesystem` (which `Sprockets::SassImporter` extends) here: https://github.com/nex3/sass/blob/stable/lib/sass/importers/filesystem.rb#L181

In other words, this should be the correct way, and the context of the importer will always be the Sprockets context if used within Sprockets. Whew.

The new way is of course preferable since Sprockets > 2.10 adds a nice `:sprockets` hash to the options hash directly, so it's still worth it to use that if it exists.
