### PR TITLE
text-rendering: optimizelegibility causes problems in some languages

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_type.scss
+++ b/vendor/assets/stylesheets/bootstrap/_type.scss
@@ -62,7 +62,7 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: $headingsFontWeight;
   line-height: $baseLineHeight;
   color: $headingsColor;
-  text-rendering: optimizelegibility; // Fix the character spacing for headings
+  //text-rendering: optimizelegibility; // Fix the character spacing for headings
   small {
     font-weight: normal;
     line-height: 1;


### PR DESCRIPTION
"text-rendering: optimizelegibility" style in _type.scss causes distortions in some languages with the current font.
Languages with 2-byte characters(Chinese, Korean, Japanese) seem to suffer from this.
I commented out optimizelegibility style that's applied in heading fonts to solve the problem.
After all, optimizelegibility does not seem necessary.
