### PR TITLE
Fix the mixins to correctly create the offset, push and pull classes

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -512,15 +512,15 @@
 }
 
 @mixin col-offset-($columns, $grid-columns) {
-  width: percentage(($columns / $grid-columns));
+  margin-left: percentage(($columns / $grid-columns));
 }
 
 @mixin col-push-($columns, $grid-columns) {
-  width: percentage(($columns / $grid-columns));
+  left: percentage(($columns / $grid-columns));
 }
 
 @mixin col-pull-($columns, $grid-columns) {
-  width: percentage(($columns / $grid-columns));
+  right: percentage(($columns / $grid-columns));
 }
 
 


### PR DESCRIPTION
The  col-offset-_, col-push-_ and col-pull-\* were not correctly generated, here is the fix.
