### PR TITLE
Plug on Rails to tell it to precompile our own images

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ gem 'bootstrap-sass', '~> 2.3.2.0'
 
 `bundle install` and restart your server to make the files available.
 
-#### Rails 4
-
-Due to a change in Rails that prevents images from being compiled in vendor and lib, you'll need to add the following line to your application.rb:
-
-    config.assets.precompile += %w(*.png *.jpg *.jpeg *.gif)
-
 #### CSS
 
 Import Bootstrap in an SCSS file (for example, `application.css.scss`) to get all of Bootstrap's styles, mixins and variables! We recommend against using `//= require` directives, since none of your other stylesheets will be [able to use](https://github.com/thomas-mcdonald/bootstrap-sass/issues/79#issuecomment-4428595) the awesome mixins that Bootstrap has defined.

--- a/lib/bootstrap-sass/engine.rb
+++ b/lib/bootstrap-sass/engine.rb
@@ -1,7 +1,9 @@
 module Bootstrap
   module Rails
     class Engine < ::Rails::Engine
-      # Rails, will you please look in our vendor? kthx
+      initializer "bootsrap-sass.assets.precompile" do |app|
+        app.config.assets.precompile += %w(glyphicons-halflings.png glyphicons-halflings-white.png)
+      end
     end
   end
 end


### PR DESCRIPTION
Rails changed the way it automatically precompile non-javascript/css files to make easier to third-party plugins to choose which files they want to precompile instead of precompiling everything under vendor or lib.

Instead of wrongly recommend users to add everything to the precompile option we should be using the engines feature to take care of our own assets.

Closes #390.
