### PR TITLE
fixed .table-striped applies to sub-tables bug

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_tables.scss
+++ b/vendor/assets/stylesheets/bootstrap/_tables.scss
@@ -154,7 +154,7 @@ table {
 
 // Default zebra-stripe styles (alternating gray and transparent backgrounds)
 .table-striped {
-  tbody {
+  > tbody {
     > tr:nth-child(odd) > td,
     > tr:nth-child(odd) > th {
       background-color: $tableBackgroundAccent;


### PR DESCRIPTION
fixed .table-striped applies to sub-tables bug

https://github.com/twbs/bootstrap/issues/5729#issuecomment-21706922
