### PR TITLE
converter: unwrap #gradient, @mixin $parent, .close button&

### DIFF
--- a/tasks/converter.rb
+++ b/tasks/converter.rb
@@ -365,7 +365,7 @@ private
     positions.each do |p|
       p = (p.begin + offset .. p.end + offset)
       r = block.call(css, p)
-      offset += r.size - p.size
+      offset += r.size - (p.end - p.begin  + 1)
       css[p] = r
     end
     css


### PR DESCRIPTION
`flatten_mixin` unwraps `#gradient { }`
`parameterize_mixin_parent_selector` applies the `@mixin a($parent)` hack
etc

not sure if this is the right approach, but it is more flexible than patches

/cc #329 @sporkd
