### PR TITLE
Updated the documentation and corrected some typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ repository. Good bug reports are extremely helpful - thank you!
 Guidelines for bug reports:
 
 1. **Does it belong here?** &mdash; is this a problem with bootstrap-sass, or
-   it an issue with [twitter/bootstrap](https://github.com/twitter/bootstrap)?
+   it an issue with [twbs/bootstrap](https://github.com/twbs/bootstrap)?
    We only distribute a direct port and will not modify files if they're not
    changed upstream.
 
@@ -57,7 +57,7 @@ Example:
 
 **We will not accept pull requests that modify the SCSS beyond fixing bugs caused by *our* code!**
 
-Most pull requests should go to [twitter/bootstrap](https://github.com/twitter/bootstrap) or [jlong/sass-twitter-bootstrap](https://github.com/jlong/sass-twitter-bootstrap)
+Most pull requests should go to [twbs/bootstrap](https://github.com/twbs/bootstrap) or [jlong/sass-twitter-bootstrap](https://github.com/jlong/sass-twitter-bootstrap)
 
 Good pull requests - patches, improvements, new features - are a fantastic
 help. They should remain focused in scope and avoid containing unrelated

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bootstrap for Sass
 
-`bootstrap-sass` is an Sass-powered version of [Twitter's Bootstrap](http://github.com/twitter/bootstrap), ready to drop right into your Sass powered applications.
+`bootstrap-sass` is an Sass-powered version of [Bootstrap](https://github.com/twbs/bootstrap), ready to drop right into your Sass powered applications.
 
 ## Usage
 
@@ -17,24 +17,24 @@ gem 'bootstrap-sass', :git => 'git://github.com/thomas-mcdonald/bootstrap-sass.g
 
 ## Upstream Converter
 
-Keeping bootstrap-sass in sync with upsteam changes from Bootstrap is an error prone and time consuming manual process.
+Keeping bootstrap-sass in sync with upstream changes from Bootstrap is an error prone and time consuming manual process.
 This branch is specifically concerned with automating that process as much as possible to allow a much faster release cycle.
 
-Upsteam changes to the Twitter Bootstrap project can now be pulled in using the `convert` rake task.
+Upstream changes to the Bootstrap project can now be pulled in using the `convert` rake task.
 
-Here's an example run that would pull down the `3.0.0-wip` branch from the main twitter/bootstrap repo:
+Here's an example run that would pull down the `3.0.0-wip` branch from the main twbs/bootstrap repo:
 
     % bundle exec rake 'convert[3.0.0-wip]'
 
-The latest converter script is located [here](https://github.com/thomas-mcdonald/bootstrap-sass/blob/3.0.0-wip/tasks/converter.rb) and does the following:
+The latest converter script is located [here](https://github.com/thomas-mcdonald/bootstrap-sass/blob/3/tasks/converter.rb) and does the following:
 
-* Converts upsteam bootstrap Less files to its matching Scss file.
-* Copies all upstream javascripts into `vendor/assets/javascripts/bootstrap`
+* Converts upstream bootstrap LESS files to its matching SCSS file.
+* Copies all upstream JavaScript into `vendor/assets/javascripts/bootstrap`
 * Generates a javascript manifest at `vendor/assets/javascripts/bootstrap.js`
 * Copies all upstream font files into `vendor/assets/fonts`
 
-This less to scss conversion is pretty good, but not perfect. So manual fixes to the resulting Scss will necessary for now.
-Please submit Github issues tagged with `conversion` to help track current shortcomings of the conversion process.
+This LESS to SCSS conversion is pretty good, but not perfect. So manual fixes to the resulting SCSS will be necessary for now.
+Please submit GitHub issues tagged with `conversion` to help track current shortcomings of the conversion process.
 
 ## Who
 bootstrap-sass is a project by [Thomas McDonald](https://twitter.com/#!/thomasmcdonald_), with support from [other awesome people](https://github.com/thomas-mcdonald/bootstrap-sass/graphs/contributors).

--- a/vendor/assets/stylesheets/bootstrap/_component-animations.scss
+++ b/vendor/assets/stylesheets/bootstrap/_component-animations.scss
@@ -5,7 +5,7 @@
 // Heads up!
 //
 // We don't use the `@include opacity()` mixin here since it causes a bug with text
-// fields in IE7-8. Source: https://github.com/twitter/bootstrap/pull/3552.
+// fields in IE7-8. Source: https://github.com/twbs/bootstrap/pull/3552.
 
 .fade {
   opacity: 0;


### PR DESCRIPTION
All upstream bootstrap links now point to the twbs/bootstrap repo.
