### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bootstrap for Sass
 
-[![Build Status](https://secure.travis-ci.org/thomas-mcdonald/bootstrap-sass.png?branch=master)](http://travis-ci.org/thomas-mcdonald/bootstrap-sass)
+[![Build Status](https://secure.travis-ci.org/thomas-mcdonald/bootstrap-sass.png?branch=master)](http://travis-ci.org/thomas-mcdonald/bootstrap-sass) [![Code Climate](https://codeclimate.com/github/thomas-mcdonald/bootstrap-sass.png)](https://codeclimate.com/github/thomas-mcdonald/bootstrap-sass)
 
 `bootstrap-sass` is an Sass-powered version of [Twitter's Bootstrap](http://github.com/twitter/bootstrap), ready to drop right into your Sass powered applications.
 


### PR DESCRIPTION
Hello,

It looks like someone (maybe you) added Bootstrap for Sass to Code Climate a little while back, and I thought you might want to know.

I work at Code Climate -- we do automated code reviews for ruby code and we're completely free for open source. I see there's just a few ruby classes here, but it's nice to have you represented on Code Climate. You can view your metrics here:

https://codeclimate.com/github/thomas-mcdonald/bootstrap-sass

In case you want this information to be available to contributors, this PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA

If you have any questions, let me know.

I hope you find Code Climate useful.

Best -

Noah
