### PR TITLE
Improve the organization of the docs -- put important things in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ gem 'sass-rails', '>= 3.2' # sass-rails needs to be higher than 3.2
 gem 'bootstrap-sass', '~> 2.3.2.1'
 ```
 
-If you would like to use the beta Bootstrap 3 version of bootstrap-sass, use the master branch: `gem 'bootstrap-sass', :github => 'thomas-mcdonald/bootstrap-sass'`
+If you would like to use the beta Bootstrap 3 version of bootstrap-sass, use the master branch:
+
+```ruby
+# Experimental Bootstrap 3.0 beta -- use at your own risk.
+gem 'sass-rails', '>= 3.2'
+gem 'bootstrap-sass', :github => 'thomas-mcdonald/bootstrap-sass'
+```
 
 `bundle install` and restart your server to make the files available through the pipeline.
 
@@ -96,14 +102,15 @@ compass install bootstrap
 
 Raw Sass support is coming soon!
 
-## Development
+## Development and Contributing
 
 If you'd like to help with the development of bootstrap-sass itself, read this section.
 
 ### Upstream Converter
 
-Keeping bootstrap-sass in sync with upstream changes from Bootstrap used to be an error prone and time consuming manual process.
-With Bootstrap 3 we have introduced a converter that automates this.
+Keeping bootstrap-sass in sync with upstream changes from Bootstrap used to be an error prone and time consuming manual process. With Bootstrap 3 we have introduced a converter that automates this.
+
+**Note: if you're just looking to *use* Bootstrap 3, see the [installation](#installation) section above.**
 
 Upstream changes to the Bootstrap project can now be pulled in using the `convert` rake task.
 


### PR DESCRIPTION
People are looking for usage docs in the README, and that's where they should be. I've seen too many "I can't run rake convert" questions over and over. This will solve that and help so many people.

Also added the word "Compass" all over the compass section to reduce confusion for Rails people.

Fixes #434 

**Note:** There's a big change in here, which is that I added docs about Bootstrap 3 and how to get it to the Installation section. I can move this just down to the Development section where people find it usually, or I can just remove the reference altogether. But I think people will ask for it and want to try it out, so it should be good.

[Preview the file in this branch here.](https://github.com/thomas-mcdonald/bootstrap-sass/blob/trisweb-update-docs-to-be-clearer/README.md)
