### PR TITLE
Fix for issue twbs/bootstrap/#7849 : jQuery.error error in tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.2.3
+
+* Fix popover/tooltip selector option bug
+
 ## 2.3.2.2
 
 * Allow sass-rails `>= 3.2` - *Thomas McDonald*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In your Gemfile:
 
 ```ruby
 gem 'sass-rails', '=> 3.2'
-gem 'bootstrap-sass', '~> 2.3.2.2'
+gem 'bootstrap-sass', '~> 2.3.2.3'
 ```
 
 `bundle install` and restart your server to make the files available.
@@ -117,7 +117,7 @@ Basically this means you should expect to append a separate patch version to the
 ### Bundler?
 
 ```ruby
-gem 'bootstrap-sass', '~> 2.3.2.2'
+gem 'bootstrap-sass', '~> 2.3.2.3'
 ```
 
 Don't use the standard `~> 2.x.y`. Your apps may break.

--- a/bootstrap-sass.gemspec
+++ b/bootstrap-sass.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "bootstrap-sass"
-  s.version = '2.3.2.2'
+  s.version = '2.3.2.3'
   s.authors = ["Thomas McDonald"]
   s.email = 'tom@conceptcoding.co.uk'
   s.summary = "Twitter's Bootstrap, converted to Sass and ready to drop into Rails or Compass"

--- a/vendor/assets/javascripts/bootstrap-tooltip.js
+++ b/vendor/assets/javascripts/bootstrap-tooltip.js
@@ -86,7 +86,7 @@
 
       this._options && $.each(this._options, function (key, value) {
         if (defaults[key] != value) options[key] = value
-      }, this)
+      })
 
       self = $(e.currentTarget)[this.type](options).data(this.type)
 


### PR DESCRIPTION
This came with commit twbs/bootstrap/@01e0f8c10547 and affects also issue issue twbs/bootstrap/#10547.
Commited here, because v2.3.2 is end of life and patches for old versions are not accepted.
Version 3 does option handling different so this patch isn't needed for version 3.
