### PR TITLE
Change grids' box-sizing to border-box

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -802,6 +802,7 @@
     // Inner gutter via padding
     padding-left:  ($grid-gutter-width / 2);
     padding-right: ($grid-gutter-width / 2);
+    @include box-sizing(border-box);
   }
 }
 


### PR DESCRIPTION
Grids have a percentage for their width and also
specify padding.  This causes the total width of
the grid to be larger than expected.
