### PR TITLE
Update sass requirement to work with the newest verison

### DIFF
--- a/bootstrap-sass.gemspec
+++ b/bootstrap-sass.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'compass'
   s.add_development_dependency 'term-ansicolor'
   s.add_development_dependency 'sass-rails', '>= 3.2'
-  s.add_runtime_dependency 'sass', '~> 3.2'
+  s.add_runtime_dependency 'sass', '>= 3.2'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'


### PR DESCRIPTION
Allow sass `3.3` to be used as well as `3.2`
