### PR TITLE
Create directory from argument in compile task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,13 +37,14 @@ task :compile, :css_path do |t, args|
   require 'term/ansicolor'
 
   path = 'vendor/assets/stylesheets'
+  css_path = args.with_defaults(css_path: 'tmp')[:css_path]
   puts Term::ANSIColor.bold "Compiling SCSS in #{path}"
+  Dir.mkdir(css_path) unless File.directory?(css_path)
   %w(bootstrap bootstrap/_theme).each do |file|
-    save_path = "#{args.with_defaults(css_path: 'tmp')[:css_path]}/#{file.sub(/(^|\/)?_+/, '\1').sub('/', '-')}.css"
+    save_path = "#{css_path}/#{file.sub(/(^|\/)?_+/, '\1').sub('/', '-')}.css"
     puts Term::ANSIColor.cyan("  #{save_path}") + '...'
     engine    = Sass::Engine.for_file("#{path}/#{file}.scss", syntax: :scss, load_paths: [path])
     css       = engine.render
-    Dir.mkdir('tmp') unless File.directory?('tmp')
     File.open(save_path, 'w') { |f| f.write css }
   end
 end


### PR DESCRIPTION
Currently, the compile task always creates a `tmp/` directory, even if
another directory is specified. The specified directory was also not created
if necessary. This PR changes the task so that it creates a specified directory (or the `tmp/` directory) first, then compiles the css into it.
