### PR TITLE
Fix incorrect path to bootstrap.scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $navbar-default-color: $light-orange;
 You can also import components explicitly. To start with a full list of modules copy this file from the gem:
 
 ```bash
-cp $(bundle show bootstrap-sass)/vendor/assets/stylesheets/bootstrap.scss \
+cp $(bundle show bootstrap-sass)/vendor/assets/stylesheets/bootstrap/bootstrap.scss \
  app/assets/stylesheets/bootstrap-custom.scss
 ```
 Comment out components you do not want from `bootstrap-custom`.


### PR DESCRIPTION
The command to copy the bootstrap.scss file (the one with all components listed) specifies the incorrect path.

It says 

cp $(bundle show bootstrap-sass)/vendor/assets/stylesheets/bootstrap.scss \
app/assets/stylesheets/bootstrap-custom.scss

when it should say 

cp $(bundle show bootstrap-sass)/vendor/assets/stylesheets/ BOOTSTRAP /bootstrap.scss ...
