### PR TITLE
Readme: Update bower package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ require 'bootstrap-sass'
 Using bootstrap-sass as a Bower package is still being tested. It is compatible with node-sass 0.8.3+. You can install it with:
 
 ```bash
-bower install twbs/bootstrap-sass
+bower install bootstrap-sass-official
 ```
 
 `bootstrap-sass` is taken so make sure you use the command above.


### PR DESCRIPTION
"twbs/bootstrap-sass" cannot be resolved when attempting to install from bower.json whereas "bootstrap-sass-official" works in both instances.
