### PR TITLE
Update Bower's `main` to contain usable JS files.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,21 @@
     "Gleb Mazovetskiy"
   ],
   "description": "bootstrap-sass is a Sass-powered version of Bootstrap, ready to drop right into your Sass powered applications.",
-  "main": ["vendor/assets/stylesheets/bootstrap.scss", "vendor/assets/javascripts/bootstrap.js"],
+  "main": [
+    "vendor/assets/stylesheets/bootstrap.scss",
+    "vendor/assets/javascripts/bootstrap/affix.js",
+    "vendor/assets/javascripts/bootstrap/alert.js",
+    "vendor/assets/javascripts/bootstrap/button.js",
+    "vendor/assets/javascripts/bootstrap/carousel.js",
+    "vendor/assets/javascripts/bootstrap/collapse.js",
+    "vendor/assets/javascripts/bootstrap/dropdown.js",
+    "vendor/assets/javascripts/bootstrap/tab.js",
+    "vendor/assets/javascripts/bootstrap/transition.js",
+    "vendor/assets/javascripts/bootstrap/scrollspy.js",
+    "vendor/assets/javascripts/bootstrap/modal.js",
+    "vendor/assets/javascripts/bootstrap/tooltip.js",
+    "vendor/assets/javascripts/bootstrap/popover.js"
+  ],
   "keywords": [
     "twbs",
     "bootstrap",


### PR DESCRIPTION
I noticed the `main` property in `bower.json` is defined as [bootstrap.js](https://github.com/twbs/bootstrap-sass/blob/master/vendor/assets/javascripts/bootstrap.js), whose contents look like this:

``` js
//= require bootstrap/affix
//= require bootstrap/alert
//= require bootstrap/button
//= require bootstrap/carousel
//= require bootstrap/collapse
//= require bootstrap/dropdown
//= require bootstrap/tab
//= require bootstrap/transition
//= require bootstrap/scrollspy
//= require bootstrap/modal
//= require bootstrap/tooltip
//= require bootstrap/popover
```

`main` is meant to define the file(s) which are usable by the consumer of your component. The file above isn't usable outside of the environment of this repository, so I simply added the individual files to the `main` array.

A better option may be to include the distributable version of `bootstrap.js`, such as the [bootstrap repo does](https://github.com/twbs/bootstrap/blob/master/bower.json#L18).
