### PR TITLE
expand bower.json main property to include partials

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "Gleb Mazovetskiy"
   ],
   "description": "bootstrap-sass is a Sass-powered version of Bootstrap, ready to drop right into your Sass powered applications.",
-  "main": ["vendor/assets/stylesheets/bootstrap.scss", "vendor/assets/javascripts/bootstrap.js"],
+  "main": "vendor/assets",
   "keywords": [
     "twbs",
     "bootstrap",


### PR DESCRIPTION
Related to issue #563

All files in `vendor/assets` have been included in the `bower.json` file. 
