### PR TITLE
correct package name in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "bootstrap-sass",
+  "name": "bootstrap-sass-official",
   "version": "3.1.1",
   "homepage": "https://github.com/twbs/bootstrap-sass",
   "authors": [


### PR DESCRIPTION
`bower.json` is currently not consistent with the docs and with what actually works when doing `bower install`.
