### PR TITLE
Fix opacity of popover arrows.

### DIFF
--- a/tasks/converter/less_conversion.rb
+++ b/tasks/converter/less_conversion.rb
@@ -452,7 +452,7 @@ SASS
     end
 
     def replace_fadein(less)
-      less.gsub(/(?![\-$@.])fadein\((.*?),\s*(.*?)%\)/) { "rgba(#{$1}, #{$2.to_i / 100.0})" }
+      less.gsub(/(?![\-$@.])fadein\((.*?),\s*(.*?)%\)/) { "fade_in(#{$1}, #{$2.to_i / 100.0})" }
     end
 
     def replace_image_urls(less)


### PR DESCRIPTION
Previously, the percentage of the LESS `fadein` function was being used directly as the opacity, which resulted in an opacity of `0.05` rather than `0.25` as the LESS version generates.

We can use the SASS `fade_in` function to more accurately generate the correct color using the same values; the only difference is that SASS's `fade_in` expects a decimal value, rather than the percentage that LESS accepts.

---

When I ran the `rake convert` task, several other unrelated files were changed, which I haven't included in this commit because it's unclear which changes are a result of this fix, and which are a result of changes in the upstream Bootstrap LESS files. Please let me know if I should explicitly include generated SASS files in this pull request, and I'll get right on it.
