### PR TITLE
Support Sprocket-sass gem so it works outside a Rails env.

### DIFF
--- a/lib/bootstrap-sass/sass_functions.rb
+++ b/lib/bootstrap-sass/sass_functions.rb
@@ -39,9 +39,12 @@ module Sass::Script::Functions
   protected
 
   def sprockets_context
-    # Modern way to get context:
+    # Modern Rails way to get context:
     if options.key?(:sprockets)
       options[:sprockets][:context]
+    # Sprockets-sass context:
+    elsif options.key?(:custom)
+      options[:custom][:sprockets_context]
     # Compatibility with sprockets pre 2.10.0:
     elsif (importer = options[:importer]) && importer.respond_to?(:context)
       importer.context


### PR DESCRIPTION
Sprockets-sass (used by Sinatra and Middleman) stores its sprockets context in a different location than Rails. This PR checks for this case and fixes: https://github.com/middleman/middleman/issues/1265
