### PR TITLE
Removed @import "bootstrap/variables";

### DIFF
--- a/templates/project/_bootstrap-variables.sass.erb
+++ b/templates/project/_bootstrap-variables.sass.erb
@@ -1,5 +1,3 @@
-@import "bootstrap/variables"
-
 <% require 'bootstrap-sass/version' %>
 // Override Bootstrap variables here (defaults from bootstrap-sass v<%= Bootstrap::VERSION %>):
 


### PR DESCRIPTION
Requires users to uncomment the whole variable chain when customizing Bootstrap.

This PR tries to address #613.
