### PR TITLE
Add autoprefixer to dependency.

### DIFF
--- a/bootstrap-sass.gemspec
+++ b/bootstrap-sass.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.license  = 'MIT'
 
   s.add_runtime_dependency 'sass', '~> 3.2'
+  s.add_runtime_dependency 'autoprefixer-rails', '~> 1.1'
 
   # Testing dependencies
   s.add_development_dependency 'test-unit', '~> 2.5.5'

--- a/lib/bootstrap-sass.rb
+++ b/lib/bootstrap-sass.rb
@@ -66,6 +66,7 @@ module Bootstrap
 
     def register_rails_engine
       require 'bootstrap-sass/engine'
+      require 'autoprefixer-rails'
     end
   end
 end


### PR DESCRIPTION
Resolves issue #616 on rails. 
Since SASS is pre-processor and autoprefixer is post-processor, I cannot find better way to keep up changes with original bootstrap.
