### PR TITLE
Add fallback positioning support on tooltips.

### DIFF
--- a/vendor/assets/javascripts/bootstrap/tooltip.js
+++ b/vendor/assets/javascripts/bootstrap/tooltip.js
@@ -174,7 +174,6 @@
         $tip
           .detach()
           .css({ top: 0, left: 0, display: 'block' })
-          .addClass(placement)
           .data('bs.' + this.type, this)
 
         this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
@@ -182,22 +181,37 @@
         var pos          = this.getPosition()
         var actualWidth  = $tip[0].offsetWidth
         var actualHeight = $tip[0].offsetHeight
+        var possible_placements = placement.split(' ')
 
         if (autoPlace) {
-          var orgPlacement = placement
-          var $parent      = this.$element.parent()
-          var parentDim    = this.getPosition($parent)
-
-          placement = placement == 'bottom' && pos.top   + pos.height       + actualHeight - parentDim.scroll > parentDim.height ? 'top'    :
-                      placement == 'top'    && pos.top   - parentDim.scroll - actualHeight < 0                                   ? 'bottom' :
-                      placement == 'right'  && pos.right + actualWidth      > parentDim.width                                    ? 'left'   :
-                      placement == 'left'   && pos.left  - actualWidth      < parentDim.left                                     ? 'right'  :
-                      placement
-
-          $tip
-            .removeClass(orgPlacement)
-            .addClass(placement)
+          switch (placement)
+          {
+            case 'bottom': possible_placements.push('top'); break
+            case 'top':    possible_placements.push('bottom'); break
+            case 'right':  possible_placements.push('left'); break
+            case 'left':   possible_placements.push('right'); break
+          }
         }
+
+        var $parent      = this.$element.parent()
+        var parentDim    = this.getPosition($parent)
+
+        for (var i = 0; i < possible_placements.length; i++) {
+          var try_placement = possible_placements[i];
+
+          if (
+            (i == possible_placements.length - 1) ||
+            (try_placement == 'bottom' && pos.top   + pos.height       + actualHeight - parentDim.scroll < parentDim.height) ||
+            (try_placement == 'top'    && pos.top   - parentDim.scroll - actualHeight > 0) ||
+            (try_placement == 'right'  && pos.right + actualWidth      < parentDim.right) ||
+            (try_placement == 'left'   && pos.left  - actualWidth      > parentDim.left)
+          ) {
+            placement = try_placement
+            break
+          }
+        }
+
+        $tip.addClass(placement)
 
         var calculatedOffset = this.getCalculatedOffset(placement, pos, actualWidth, actualHeight)
 


### PR DESCRIPTION
Now you can use `placement: 'right bottom left top'` instead of just
`placement: 'auto right'` to fallback through multiple options until we
find one that fits. (`auto right` still works as before.)
- Fixes #7399 (with manual specification of the fallback order).
- Fixes #7988 (that was closed and the follow-up is not obvious).
- Fixes #1833 (by allowing alternative placements @mindplay-dk).
- Fixes #13897 (also includes the fix for right-placement calculation).
