### PR TITLE
use-navbar-inverse-border

### DIFF
--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -584,7 +584,7 @@
 
   .navbar-collapse,
   .navbar-form {
-    border-color: darken($navbar-inverse-bg, 7%);
+    border-color: $navbar-inverse-border;
   }
 
   // Dropdowns


### PR DESCRIPTION
In `.navbar-default`,  `.navbar-collapse, .navbar-form` is `border-color: $navbar-default-border;` but in `.navbar-inverse'`, `.navbar-collapse, .navbar-form` is hard-coded like `border-color: darken($navbar-inverse-bg, 7%);`.

Does this has some means? I think `border-color: $navbar-inverse-border;` is better though `$navbar-inverse-border` is different from `darken($navbar-inverse-bg, 7%)`.
