### PR TITLE
add nodejs dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,10 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/twbs/bootstrap-sass/issues"
+  },
+  "devDependencies": {
+    "node-sass": "*",
+    "mincer": "*",
+    "ejs": "*"
   }
 }


### PR DESCRIPTION
I think [.travis.yml](https://github.com/twbs/bootstrap-sass/blob/master/.travis.yml#L11) is not good place to declare dependencies. With this commit we can install nodejs dependencies in easiest way : `npm install`, like `bundler install`.
