### PR TITLE
Remove 'images' folder from precompile list

### DIFF
--- a/lib/bootstrap-sass/engine.rb
+++ b/lib/bootstrap-sass/engine.rb
@@ -2,7 +2,7 @@ module Bootstrap
   module Rails
     class Engine < ::Rails::Engine
       initializer 'bootstrap-sass.assets.precompile' do |app|
-        %w(stylesheets javascripts fonts images).each do |sub|
+        %w(stylesheets javascripts fonts).each do |sub|
           app.config.assets.paths << root.join('assets', sub)
         end
         app.config.assets.precompile << %r(bootstrap/glyphicons-halflings-regular\.(?:eot|svg|ttf|woff)$)


### PR DESCRIPTION
Not including the 'assets/images' folder fixes precomilation in Rails 4.2.0.beta1. Since the folder doesn't exist a `Errno::ENOENT (No such file or directory @ realpath_rec - /Users/alex/.rvm/gems/ruby-2.1.1/gems/bootstrap-sass-3.2.0.1/assets/images` is raised during precompilation.
