### PR TITLE
Fix a broken link url of bootstrap.scss in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ See also this [example manifest.js](/test/dummy_node_mincer/manifest.js) for min
 By default all of Bootstrap is imported.
 
 You can also import components explicitly. To start with a full list of modules copy
-[`bootstrap.scss`](assets/stylesheets/bootstrap.scss) file into your assets as `bootstrap-custom.scss`.
+[`bootstrap.scss`](assets/stylesheets/_bootstrap.scss) file into your assets as `bootstrap-custom.scss`.
 Then comment out components you do not want from `bootstrap-custom`.
 In the application Sass file, replace `@import 'bootstrap'` with:
 


### PR DESCRIPTION
In the README.md file in the Configuration Section,
The hypelink "bootstrap.scss" is pointing to a **broken url** `assets/stylesheets/bootstrap.scss`
The actual url should be `assets/stylesheets/_bootstrap.scss`
