### PR TITLE
Change parameters which passed in the rgba function

### DIFF
--- a/assets/stylesheets/bootstrap/mixins/_forms.scss
+++ b/assets/stylesheets/bootstrap/mixins/_forms.scss
@@ -49,7 +49,7 @@
 // Example usage: change the default blue border and shadow to white for better
 // contrast against a dark gray background.
 @mixin form-control-focus($color: $input-border-focus) {
-  $color-rgba: rgba(red($color), green($color), blue($color), .6);
+  $color-rgba: rgba($color, .6);
   &:focus {
     border-color: $color;
     outline: 0;


### PR DESCRIPTION
No reason to convert HEX to RGB because Sass has two overloads of rgba() method and one of them allows us to pass color in the HEX format

Link to docs: http://sass-lang.com/documentation/Sass/Script/Functions.html#rgba-instance_method
