### PR TITLE
Added mixin background-size

### DIFF
--- a/assets/stylesheets/bootstrap/_mixins.scss
+++ b/assets/stylesheets/bootstrap/_mixins.scss
@@ -29,6 +29,7 @@
 // Skins
 @import "mixins/background-variant";
 @import "mixins/border-radius";
+@import "mixins/background-size";
 @import "mixins/gradients";
 
 // Layout

--- a/assets/stylesheets/bootstrap/mixins/_background-size.scss
+++ b/assets/stylesheets/bootstrap/mixins/_background-size.scss
@@ -1,0 +1,6 @@
+@mixin background-size($size) {
+  background-size: $size;
+  -moz-background-size: $size;
+  -o-background-size: $size;
+  -webkit-background-size: $size;
+}


### PR DESCRIPTION
For ability to set, for example, CSS propery background-size: cover; to
cross-browser image centering.
