### PR TITLE
Fix uninitialized constant Bootstrap::VERSION (NameError) error

### DIFF
--- a/lib/bootstrap-sass.rb
+++ b/lib/bootstrap-sass.rb
@@ -53,6 +53,8 @@ module Bootstrap
     end
 
     def register_compass_extension
+      require 'bootstrap-sass/version'
+
       ::Compass::Frameworks.register(
           'bootstrap',
           :version               => Bootstrap::VERSION,


### PR DESCRIPTION
Bootstrap::VERSION is not included so can't boot my app :(. Perhaps we'll need to yank and rebuild 3.3.0.0.
