### PR TITLE
Use mixins for vendor prefixes in carousel transitions

### DIFF
--- a/assets/stylesheets/bootstrap/_carousel.scss
+++ b/assets/stylesheets/bootstrap/_carousel.scss
@@ -27,24 +27,24 @@
 
     // WebKit CSS3 transforms for supported devices
     @media all and (transform-3d), (-webkit-transform-3d) {
-      transition: transform .6s ease-in-out;
-      backface-visibility: hidden;
-      perspective: 1000;
+      @include transition-transform(0.6s ease-in-out);
+      @include backface-visibility(hidden);
+      @include perspective(1000);
 
       &.next,
       &.active.right {
-        transform: translate3d(100%, 0, 0);
+        @include translate3d(100%, 0, 0);
         left: 0;
       }
       &.prev,
       &.active.left {
-        transform: translate3d(-100%, 0, 0);
+        @include translate3d(-100%, 0, 0);
         left: 0;
       }
       &.next.left,
       &.prev.right,
       &.active {
-        transform: translate3d(0, 0, 0);
+        @include translate3d(0, 0, 0);
         left: 0;
       }
     }


### PR DESCRIPTION
Fixes carousel transitions to use mixins and match the browser support provided in the original LESS version of bootstrap.  Please see https://github.com/twbs/bootstrap/pull/13074/files

Thanks!
