### PR TITLE
Removing Rails 3.2 instructions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In your Gemfile you need to add the `bootstrap-sass` gem, and ensure that the `s
 
 ```ruby
 gem 'bootstrap-sass', '~> 3.3.0'
-gem 'sass-rails', '>= 3.2'
+gem 'sass-rails', '>= 4.0'
 ```
 
 It is also recommended to use [Autoprefixer](https://github.com/ai/autoprefixer-rails) with Bootstrap
@@ -92,17 +92,7 @@ Please make sure `sprockets-rails` is at least v2.1.4.
 
 #### Rails 3.2.x
 
-Rails 3.2 is [no longer maintained for bugfixes](http://guides.rubyonrails.org/maintenance_policy.html), and you should upgrade as soon as possible.
-
-Starting with bootstrap-sass v3.1.1.1, due to the structural changes from upstream you will need these
-backported asset pipeline gems on Rails 3.2. There is more on why this is necessary in
-https://github.com/twbs/bootstrap-sass/issues/523 and https://github.com/twbs/bootstrap-sass/issues/578.
-
-```ruby
-gem 'sprockets-rails', '=2.0.0.backport1'
-gem 'sprockets', '=2.2.2.backport2'
-gem 'sass-rails', github: 'guilleiguaran/sass-rails', branch: 'backport'
-```
+Rails 3.2 is no longer supported.
 
 ### b. Compass without Rails
 


### PR DESCRIPTION
Fixes #764
