### PR TITLE
Fix border issue on nav tabs when justified

### DIFF
--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -85,6 +85,8 @@
       margin-right: 2px;
       line-height: $line-height-base;
       border: 1px solid transparent;
+      border-left: none;
+      border-right: none;
       border-radius: $border-radius-base $border-radius-base 0 0;
       &:hover {
         border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;


### PR DESCRIPTION
When we use `.nav-tabs.nav-justified`, there is a small space between the border-bottoms of the tabs.

Fixed this issue, so the border-bottom has no interruptions.
