### PR TITLE
Fix line-height error in input-size mixin.

### DIFF
--- a/assets/stylesheets/bootstrap/mixins/_forms.scss
+++ b/assets/stylesheets/bootstrap/mixins/_forms.scss
@@ -78,7 +78,7 @@
 
   select#{$parent} {
     height: $input-height;
-    line-height: $input-height;
+    line-height: $line-height;
   }
 
   textarea#{$parent},


### PR DESCRIPTION
There was an error in the input-size mixin that caused some input fields to have a height too important.