### PR TITLE
display: table-column added to responsive visibility if used on <col>

### DIFF
--- a/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss
+++ b/assets/stylesheets/bootstrap/mixins/_responsive-visibility.scss
@@ -11,6 +11,7 @@
   tr#{$parent}     { display: table-row !important; }
   th#{$parent},
   td#{$parent}     { display: table-cell !important; }
+  col#{$parent}    { display: table-column !important; }
 }
 
 // [converter] $parent hack


### PR DESCRIPTION
Problem: By using the ".hidden-xx" and ".visible-xx" classes on a "col" element, it got displayed as block. This leads to problems when using tables with fixed layout.