### PR TITLE
bower.json: Remove font files from `main`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,11 +11,6 @@
   "description": "bootstrap-sass is a Sass-powered version of Bootstrap, ready to drop right into your Sass powered applications.",
   "main": [
     "assets/stylesheets/_bootstrap.scss",
-    "assets/fonts/bootstrap/glyphicons-halflings-regular.eot",
-    "assets/fonts/bootstrap/glyphicons-halflings-regular.svg",
-    "assets/fonts/bootstrap/glyphicons-halflings-regular.ttf",
-    "assets/fonts/bootstrap/glyphicons-halflings-regular.woff",
-    "assets/fonts/bootstrap/glyphicons-halflings-regular.woff2",
     "assets/javascripts/bootstrap.js"
   ],
   "keywords": [


### PR DESCRIPTION
Per https://github.com/bower/bower.json-spec/pull/43 :
> font files [...] are not `main` files as they are not entry-points.

Refs https://github.com/twbs/bootstrap/pull/16359