### PR TITLE
added a variable for \00a0 unicode character for breadcrumb

### DIFF
--- a/assets/stylesheets/bootstrap/_breadcrumbs.scss
+++ b/assets/stylesheets/bootstrap/_breadcrumbs.scss
@@ -14,7 +14,7 @@
     display: inline-block;
 
     + li:before {
-      content: "#{$breadcrumb-separator}\00a0"; // Unicode space added since inline-block means non-collapsing white-space
+      content: "#{$breadcrumb-separator}#{$breadcrumb-nonbreaking-space}"; // Unicode space added since inline-block means non-collapsing white-space
       padding: 0 5px;
       color: $breadcrumb-color;
     }

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -796,6 +796,7 @@ $breadcrumb-color:              #ccc !default;
 $breadcrumb-active-color:       $gray-light !default;
 //** Textual separator for between breadcrumb elements
 $breadcrumb-separator:          "/" !default;
+$breadcrumb-nonbreaking-space:  "\00a0";
 
 
 //== Carousel


### PR DESCRIPTION
When used with certain preprocessor, the "\00a0" string gets converted to "\\00a0" unless it is in a variable, which shows the full string rather than an empty space on webpage. This is aimed to fix that. For reference:

http://stackoverflow.com/questions/21608762/sass-variable-interpolation-with-backslash-in-output