### PR TITLE
Change minimum sass version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.1.5
 gemfile:
-  - test/gemfiles/sass_3_2.gemfile
   - test/gemfiles/sass_3_3.gemfile
   - test/gemfiles/sass_3_4.gemfile
   - test/gemfiles/sass_head.gemfile

--- a/bootstrap-sass.gemspec
+++ b/bootstrap-sass.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/twbs/bootstrap-sass"
   s.license  = 'MIT'
 
-  s.add_runtime_dependency 'sass', '>= 3.2.19'
+  s.add_runtime_dependency 'sass', '>= 3.3.0'
   s.add_runtime_dependency 'autoprefixer-rails', '>= 5.0.0.1'
 
   # Testing dependencies

--- a/test/dummy_sass_only/Gemfile
+++ b/test/dummy_sass_only/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'sass', '~> 3.2'
+gem 'sass', '~> 3.3'
 gem 'bootstrap-sass', path: '../..'

--- a/test/gemfiles/sass_3_2.gemfile
+++ b/test/gemfiles/sass_3_2.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem 'sass', '~> 3.2.0'
-gem 'compass', require: false
-
-gemspec path: '../../'


### PR DESCRIPTION
As of version 3.3.5, the @at-root sass feature has been introduced:
https://github.com/twbs/bootstrap-sass/commit/2579e3374f146d85ce517cc368fb54c9d198ecc8 https://github.com/twbs/bootstrap-sass/pull/805

This feature depends on sass >= 3.3.

See also:
https://github.com/twbs/bootstrap-sass/issues/920