### PR TITLE
Update default font-family to variable _normalize.scss

### DIFF
--- a/assets/stylesheets/bootstrap/_normalize.scss
+++ b/assets/stylesheets/bootstrap/_normalize.scss
@@ -7,7 +7,7 @@
 //
 
 html {
-  font-family: sans-serif; // 1
+  font-family: $font-family-base; // 1
   -ms-text-size-adjust: 100%; // 2
   -webkit-text-size-adjust: 100%; // 2
 }


### PR DESCRIPTION
Changed default html font-family to '$font-family-base' to prevents 'san-serif' from overriding inheritance from custom fonts set in 'variables' (normalize is imported after variables).