### PR TITLE
Add support for `sprockets-rails` 3 and `sprockets` 4.

### DIFF
--- a/lib/bootstrap-sass/engine.rb
+++ b/lib/bootstrap-sass/engine.rb
@@ -5,7 +5,12 @@ module Bootstrap
         %w(stylesheets javascripts fonts images).each do |sub|
           app.config.assets.paths << root.join('assets', sub).to_s
         end
-        app.config.assets.precompile << %r(bootstrap/glyphicons-halflings-regular\.(?:eot|svg|ttf|woff2?)$)
+
+        # sprockets-rails 3 tracks down the calls to `font_path` and `image_path`
+        # and automatically precompiles the referenced assets.
+        unless Sprockets::Rails::VERSION.starts_with?('3')
+          app.config.assets.precompile << %r(bootstrap/glyphicons-halflings-regular\.(?:eot|svg|ttf|woff2?)$)
+        end
       end
     end
   end


### PR DESCRIPTION
`sprockets-rails` 3 already precompiles any asset that is referenced by the `font-path` and `image-path` helpers, and `sprockets` 4 does not support Regexpes as the `precompile` flag.