### PR TITLE
Use #default_max_wait_time= instead of #default_wait_time=

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,6 @@ Capybara.configure do |config|
   config.default_driver    = :poltergeist
   config.javascript_driver = :poltergeist
   config.server_port       = 7000
-  config.default_wait_time = 10
+  config.default_max_wait_time = 10
 end
 


### PR DESCRIPTION
I get bwlow deprecated warning when I run `bundle exec rake test`.

```
DEPRECATED: #default_wait_time= is deprecated, please use #default_max_wait_time= instead
```
