### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Gem Version](https://badge.fury.io/rb/bootstrap-sass.svg)](http://badge.fury.io/rb/bootstrap-sass)
 [![npm version](https://img.shields.io/npm/v/bootstrap-sass.svg?style=flat)](https://www.npmjs.com/package/bootstrap-sass)
 [![Bower Version](https://badge.fury.io/bo/bootstrap-sass.svg)](http://badge.fury.io/bo/bootstrap-sass)
-[![Build Status](http://img.shields.io/travis/twbs/bootstrap-sass.svg)](http://travis-ci.org/twbs/bootstrap-sass)
+[![Build Status](https://img.shields.io/travis/twbs/bootstrap-sass.svg)](https://travis-ci.org/twbs/bootstrap-sass)
 
-`bootstrap-sass` is a Sass-powered version of [Bootstrap](http://github.com/twbs/bootstrap), ready to drop right into your Sass powered applications.
+`bootstrap-sass` is a Sass-powered version of [Bootstrap](https://github.com/twbs/bootstrap), ready to drop right into your Sass powered applications.
 
 ## Installation
 
@@ -340,8 +340,8 @@ and a [significant number of other contributors][contrib].
 ## You're in good company
 bootstrap-sass is used to build some awesome projects all over the web, including
 [Diaspora](https://diasporafoundation.org/), [rails_admin](https://github.com/sferik/rails_admin),
-Michael Hartl's [Rails Tutorial](http://railstutorial.org/), [gitlabhq](http://gitlabhq.com/) and
-[kandan](http://kandan.io/).
+Michael Hartl's [Rails Tutorial](https://www.railstutorial.org/), [gitlabhq](http://gitlabhq.com/) and
+[kandan](http://getkandan.com/).
 
 [converter]: https://github.com/twbs/bootstrap-sass/blob/master/tasks/converter/less_conversion.rb
 [version]: https://github.com/twbs/bootstrap-sass/blob/master/lib/bootstrap-sass/version.rb
@@ -350,4 +350,4 @@ Michael Hartl's [Rails Tutorial](http://railstutorial.org/), [gitlabhq](http://g
 [jsdocs]: http://getbootstrap.com/javascript/#transitions
 [sass-precision]: http://sass-lang.com/documentation/Sass/Script/Value/Number.html#precision%3D-class_method
 [mincer]: https://github.com/nodeca/mincer
-[autoprefixer]: https://github.com/ai/autoprefixer
+[autoprefixer]: https://github.com/postcss/autoprefixer


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Main Corrected URLs 
Was | Now 
--- | --- 
http://kandan.io/ | http://getkandan.com/ 
https://github.com/ai/autoprefixer | https://github.com/postcss/autoprefixer 

### HTTPS Other Corrected URLs 
Was | Now 
--- | --- 
http://travis-ci.org/twbs/bootstrap-sass | https://travis-ci.org/twbs/bootstrap-sass 
http://github.com/twbs/bootstrap | https://github.com/twbs/bootstrap 
http://img.shields.io/travis/twbs/bootstrap-sass.svg | https://img.shields.io/travis/twbs/bootstrap-sass.svg 
http://railstutorial.org/ | https://www.railstutorial.org/ 
