### PR TITLE
Add Eyeglass support to Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,22 @@ $navbar-default-color: $light-orange;
 @import "bootstrap";
 ```
 
+### Eyeglass
+
+Boodstrap is available as an [Eyeglass](https://github.com/sass-eyeglass/eyeglass) module. After installing Bootstrap via NPM you can import the Bootstrap library via:
+
+```scss
+@import "bootstrap-sass/bootstrap"
+```
+
+or import only the parts of Bootstrap you need:
+
+```scss
+@import "bootstrap-sass/bootstrap/variables";
+@import "bootstrap-sass/bootstrap/mixins";
+@import "bootstrap-sass/bootstrap/carousel";
+```
+
 ## Version
 
 Bootstrap for Sass version may differ from the upstream version in the last number, known as

--- a/eyeglass-exports.js
+++ b/eyeglass-exports.js
@@ -1,0 +1,7 @@
+var path = require('path');
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: path.join(__dirname, 'assets/stylesheets')
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
     "node-sass": "~3.4.2",
     "mincer": "~1.3",
     "ejs": "~2.3"
+  },
+  "eyeglass": {
+    "exports": "eyeglass-exports.js",
+    "needs": "^0.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "keywords": [
     "bootstrap",
     "sass",
-    "css"
+    "css",
+    "eyeglass-module"
   ],
   "contributors": [
     "Thomas McDonald",


### PR DESCRIPTION
I added [Eyeglass](https://github.com/sass-eyeglass/eyeglass) support to Bootstrap. If someone is using Eyeglass they can now work with Bootstrap without having to edit the library or move Bootstrap from their node_modules folder.