### PR TITLE
Granular Includes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,8 @@
   "description": "bootstrap-sass is a Sass-powered version of Bootstrap 3, ready to drop right into your Sass powered applications.",
   "moduleType": "globals",
   "main": [
-    "assets/stylesheets/_bootstrap.scss",
-    "assets/javascripts/bootstrap.js"
+    "assets/stylesheets/**/*.scss",
+    "assets/javascripts/**/*.js"
   ],
   "keywords": [
     "twbs",


### PR DESCRIPTION
Use globs instead of explicit top level file names. This makes it possible to only include specific SCSS files in applications that use this library