### PR TITLE
Require capybara/dsl instead of capybara

### DIFF
--- a/test/support/dummy_rails_integration.rb
+++ b/test/support/dummy_rails_integration.rb
@@ -1,4 +1,4 @@
-require 'capybara'
+require 'capybara/dsl'
 require 'fileutils'
 module DummyRailsIntegration
   include Capybara::DSL


### PR DESCRIPTION
Thank you for great gem.

I fix below failure on capybara.

https://travis-ci.org/twbs/bootstrap-sass/builds/106712085
