### PR TITLE
Add .npmignore to mirror Bower ignored files.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+**/.*
+lib
+tasks
+templates
+test
+*.gemspec
+Rakefile
+Gemfile


### PR DESCRIPTION
I ran into a problem switching from using bower to npm for bootstrap-sass, and realized that a bunch of files were included in the NPM module that weren't in the bower package.

See https://docs.npmjs.com/files/package.json#files for more info on files included in NPM modules.  It's worth noting that `.npmignore` is basically merged with `.gitignore` to determine what files are filtered from the published package.

This is a very conservative approach - it may in fact be better to just specify the assets directory (plus README, LICENSE, etc.) in the `files` section of `package.json`.  You could also ignore other non-npm-related files like `bower.json` etc.