### PR TITLE
Make spaces in contenteditables work in Dropdown

### DIFF
--- a/assets/javascripts/bootstrap/dropdown.js
+++ b/assets/javascripts/bootstrap/dropdown.js
@@ -92,7 +92,9 @@
   }
 
   Dropdown.prototype.keydown = function (e) {
-    if (!/(38|40|27|32)/.test(e.which) || /input|textarea/i.test(e.target.tagName)) return
+    if (!/(38|40|27|32)/.test(e.which)
+        || /input|textarea/i.test(e.target.tagName)
+        || e.target.attributes.getNamedItem('contenteditable') != null) return
 
     var $this = $(this)
 


### PR DESCRIPTION
Currently Dropdown will slurp spaces in contenteditables.
This patch turns off slurping of spaces so contenteditables behave as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twbs/bootstrap-sass/1036)
<!-- Reviewable:end -->
