### PR TITLE
Update dependencies, jquery 3.0 was just rolled out and hard errors if installed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "Gemfile"
   ],
   "dependencies": {
-    "jquery": ">= 1.9.0"
+    "jquery": "1.9.1 - 2"
   },
   "version": "3.3.6"
 }


### PR DESCRIPTION
For Issue: #1042, ran into an issue deploying today that caused Bootstrap to hard error from the dependency in bootstrap-sass allowing 3.0.0 jquery to be installed.  Updated the dependency to match that of Bootstrap.