### PR TITLE
added style field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.6",
   "description": "bootstrap-sass is a Sass-powered version of Bootstrap 3, ready to drop right into your Sass powered applications.",
   "main": "assets/javascripts/bootstrap.js",
+  "style": "assets/stylesheets/_bootstrap.scss",
   "repository": {
     "type": "git",
     "url": "git://github.com/twbs/bootstrap-sass"


### PR DESCRIPTION
So it can be imported directly into sass with `@import 'bootstrap-sass';` using the importer [`sass-module-importer`](https://github.com/lucasmotta/sass-module-importer).

Also discussed about this in issue #1045.