### PR TITLE
Remove extra parens

### DIFF
--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -365,7 +365,7 @@ $container-lg:                 $container-large-desktop !default;
 $navbar-height:                    50px !default;
 $navbar-margin-bottom:             $line-height-computed !default;
 $navbar-border-radius:             $border-radius-base !default;
-$navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;
+$navbar-padding-horizontal:        floor($grid-gutter-width / 2) !default;
 $navbar-padding-vertical:          (($navbar-height - $line-height-computed) / 2) !default;
 $navbar-collapse-max-height:       340px !default;
 


### PR DESCRIPTION
As of `"node-sass": "3.3"`, checked that it is parsing correctly. Made a gist to demonstrate:

https://www.sassmeister.com/gist/fc77f10337d940ea3a1015b5e524dee8