### PR TITLE
Update README.md advising use of jquery-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Then, remove all the `*= require_self` and `*= require_tree .` statements from t
 
 Do not use `*= require` in Sass or your other stylesheets will not be [able to access][antirequire] the Bootstrap mixins or variables.
 
+Bootstrap JavaScript depends on jQuery.
+If you're using Rails 5.1+, add the `jquery-rails` gem to your Gemfile:
+
+```ruby
+gem 'jquery-rails'
+```
+
+```console
+$ bundle install
+```
+
 Require Bootstrap Javascripts in `app/assets/javascripts/application.js`:
 
 ```js


### PR DESCRIPTION
Users running Rails 5.1+ are required to also add jquery-rails to their Gemfile otherwise missing jquery dependency occurs. The other Bootstrap 4 version already includes this instruction in its readme file [here on line 47](https://github.com/twbs/bootstrap-rubygem/blob/master/README.md)