### PR TITLE
Update ejs version because of potential security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "node-sass": "^3.8.0",
     "mincer": "~1.4.0",
-    "ejs": "~2.4.2"
+    "ejs": "< 2.5.5"
   },
   "eyeglass": {
     "exports": "eyeglass-exports.js",


### PR DESCRIPTION
The ejs has a known moderate severity security vulnerability in version range `< 2.5.5` and should be updated