### PR TITLE
Dropdown menuにactive要素を追加

### DIFF
--- a/assets/stylesheets/bootstrap/_badges.scss
+++ b/assets/stylesheets/bootstrap/_badges.scss
@@ -59,10 +59,12 @@
 
 // Hover state, but only for links
 a.badge {
-  &:hover,
-  &:focus {
-    color: $badge-link-hover-color;
-    text-decoration: none;
-    cursor: pointer;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $badge-link-hover-color;
+      text-decoration: none;
+      cursor: pointer;
+    }
   }
 }

--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -29,11 +29,12 @@
     }
   }
 
-  &:hover,
-  &:focus,
-  &.focus {
-    color: $btn-default-color;
-    text-decoration: none;
+  @include hover-support {
+    &:hover,
+    &:focus,
+    &.focus {
+      color: $btn-default-color;
+    }
   }
 
   &:active,
@@ -112,11 +113,13 @@ a.btn {
   &:active {
     border-color: transparent;
   }
-  &:hover,
-  &:focus {
-    color: $link-hover-color;
-    text-decoration: $link-hover-decoration;
-    background-color: transparent;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $link-hover-color;
+      text-decoration: $link-hover-decoration;
+      background-color: transparent;
+    }
   }
   &[disabled],
   fieldset[disabled] & {

--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -42,6 +42,7 @@
   &.active {
     outline: 0;
     background-image: none;
+    text-decoration: none;
     @include box-shadow(inset 0 3px 5px rgba(0,0,0,.125));
   }
 

--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -34,6 +34,7 @@
     &:focus,
     &.focus {
       color: $btn-default-color;
+      text-decoration: none;
     }
   }
 

--- a/assets/stylesheets/bootstrap/_carousel.scss
+++ b/assets/stylesheets/bootstrap/_carousel.scss
@@ -116,12 +116,14 @@
   }
 
   // Hover/focus state
-  &:hover,
-  &:focus {
-    outline: 0;
-    color: $carousel-control-color;
-    text-decoration: none;
-    @include opacity(.9);
+  @include hover-support {
+    &:hover,
+    &:focus {
+      outline: 0;
+      color: $carousel-control-color;
+      text-decoration: none;
+      @include opacity(.9);
+    }
   }
 
   // Toggles

--- a/assets/stylesheets/bootstrap/_close.scss
+++ b/assets/stylesheets/bootstrap/_close.scss
@@ -12,12 +12,14 @@
   text-shadow: $close-text-shadow;
   @include opacity(.2);
 
-  &:hover,
-  &:focus {
-    color: $close-color;
-    text-decoration: none;
-    cursor: pointer;
-    @include opacity(.5);
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $close-color;
+      text-decoration: none;
+      cursor: pointer;
+      @include opacity(.5);
+    }
   }
 
   // [converter] extracted button& to button.close

--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -70,16 +70,25 @@
     line-height: $line-height-base;
     color: $dropdown-link-color;
     white-space: nowrap; // prevent links from randomly breaking onto new lines
+    @include user-select(none);
   }
 }
 
 // Hover/Focus state
 .dropdown-menu > li > a {
-  &:hover,
-  &:focus {
+  &:active {
     text-decoration: none;
     color: $dropdown-link-hover-color;
     background-color: $dropdown-link-hover-bg;
+  }
+
+  @include hover-support {
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      color: $dropdown-link-hover-color;
+      background-color: $dropdown-link-hover-bg;
+    }
   }
 }
 
@@ -87,6 +96,7 @@
 .dropdown-menu > .active > a {
   &,
   &:hover,
+  &:active,
   &:focus {
     color: $dropdown-link-active-color;
     text-decoration: none;
@@ -102,12 +112,14 @@
 .dropdown-menu > .disabled > a {
   &,
   &:hover,
+  &:active,
   &:focus {
     color: $dropdown-link-disabled-color;
   }
 
-  // Nuke hover/focus effects
+  // Nuke hover/active/focus effects
   &:hover,
+  &:active,
   &:focus {
     text-decoration: none;
     background-color: transparent;

--- a/assets/stylesheets/bootstrap/_labels.scss
+++ b/assets/stylesheets/bootstrap/_labels.scss
@@ -30,11 +30,13 @@
 
 // Add hover effects, but only for links
 a.label {
-  &:hover,
-  &:focus {
-    color: $label-link-hover-color;
-    text-decoration: none;
-    cursor: pointer;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $label-link-hover-color;
+      text-decoration: none;
+      cursor: pointer;
+    }
   }
 }
 

--- a/assets/stylesheets/bootstrap/_list-group.scss
+++ b/assets/stylesheets/bootstrap/_list-group.scss
@@ -52,11 +52,13 @@ button.list-group-item {
   }
 
   // Hover state
-  &:hover,
-  &:focus {
-    text-decoration: none;
-    color: $list-group-link-hover-color;
-    background-color: $list-group-hover-bg;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      color: $list-group-link-hover-color;
+      background-color: $list-group-hover-bg;
+    }
   }
 }
 

--- a/assets/stylesheets/bootstrap/_mixins.scss
+++ b/assets/stylesheets/bootstrap/_mixins.scss
@@ -2,6 +2,7 @@
 // --------------------------------------------------
 
 // Utilities
+@import 'mixins/hover';
 @import "mixins/hide-text";
 @import "mixins/opacity";
 @import "mixins/image";

--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -400,10 +400,12 @@
 
   .navbar-brand {
     color: $navbar-default-brand-color;
-    &:hover,
-    &:focus {
-      color: $navbar-default-brand-hover-color;
-      background-color: $navbar-default-brand-hover-bg;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $navbar-default-brand-hover-color;
+        background-color: $navbar-default-brand-hover-bg;
+      }
     }
   }
 
@@ -415,10 +417,12 @@
     > li > a {
       color: $navbar-default-link-color;
 
-      &:hover,
-      &:focus {
-        color: $navbar-default-link-hover-color;
-        background-color: $navbar-default-link-hover-bg;
+      @include hover-support {
+        &:hover,
+        &:focus {
+          color: $navbar-default-link-hover-color;
+          background-color: $navbar-default-link-hover-bg;
+        }
       }
     }
     > .active > a {
@@ -441,9 +445,11 @@
 
   .navbar-toggle {
     border-color: $navbar-default-toggle-border-color;
-    &:hover,
-    &:focus {
-      background-color: $navbar-default-toggle-hover-bg;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        background-color: $navbar-default-toggle-hover-bg;
+      }
     }
     .icon-bar {
       background-color: $navbar-default-toggle-icon-bar-bg;
@@ -472,10 +478,12 @@
       .open .dropdown-menu {
         > li > a {
           color: $navbar-default-link-color;
-          &:hover,
-          &:focus {
-            color: $navbar-default-link-hover-color;
-            background-color: $navbar-default-link-hover-bg;
+          @include hover-support {
+            &:hover,
+            &:focus {
+              color: $navbar-default-link-hover-color;
+              background-color: $navbar-default-link-hover-bg;
+            }
           }
         }
         > .active > a {
@@ -512,9 +520,11 @@
 
   .btn-link {
     color: $navbar-default-link-color;
-    &:hover,
-    &:focus {
-      color: $navbar-default-link-hover-color;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $navbar-default-link-hover-color;
+      }
     }
     &[disabled],
     fieldset[disabled] & {
@@ -534,10 +544,12 @@
 
   .navbar-brand {
     color: $navbar-inverse-brand-color;
-    &:hover,
-    &:focus {
-      color: $navbar-inverse-brand-hover-color;
-      background-color: $navbar-inverse-brand-hover-bg;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $navbar-inverse-brand-hover-color;
+        background-color: $navbar-inverse-brand-hover-bg;
+      }
     }
   }
 
@@ -548,11 +560,12 @@
   .navbar-nav {
     > li > a {
       color: $navbar-inverse-link-color;
-
-      &:hover,
-      &:focus {
-        color: $navbar-inverse-link-hover-color;
-        background-color: $navbar-inverse-link-hover-bg;
+      @include hover-support {
+        &:hover,
+        &:focus {
+          color: $navbar-inverse-link-hover-color;
+          background-color: $navbar-inverse-link-hover-bg;
+        }
       }
     }
     > .active > a {
@@ -576,9 +589,11 @@
   // Darken the responsive nav toggle
   .navbar-toggle {
     border-color: $navbar-inverse-toggle-border-color;
-    &:hover,
-    &:focus {
-      background-color: $navbar-inverse-toggle-hover-bg;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        background-color: $navbar-inverse-toggle-hover-bg;
+      }
     }
     .icon-bar {
       background-color: $navbar-inverse-toggle-icon-bar-bg;
@@ -612,10 +627,12 @@
         }
         > li > a {
           color: $navbar-inverse-link-color;
-          &:hover,
-          &:focus {
-            color: $navbar-inverse-link-hover-color;
-            background-color: $navbar-inverse-link-hover-bg;
+          @include hover-support {
+            &:hover,
+            &:focus {
+              color: $navbar-inverse-link-hover-color;
+              background-color: $navbar-inverse-link-hover-bg;
+            }
           }
         }
         > .active > a {
@@ -640,16 +657,20 @@
 
   .navbar-link {
     color: $navbar-inverse-link-color;
-    &:hover {
-      color: $navbar-inverse-link-hover-color;
+    @include hover-support {
+      &:hover {
+        color: $navbar-inverse-link-hover-color;
+      }
     }
   }
 
   .btn-link {
     color: $navbar-inverse-link-color;
-    &:hover,
-    &:focus {
-      color: $navbar-inverse-link-hover-color;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $navbar-inverse-link-hover-color;
+      }
     }
     &[disabled],
     fieldset[disabled] & {

--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -236,6 +236,7 @@
     padding-top:    10px;
     padding-bottom: 10px;
     line-height: $line-height-computed;
+    @include user-select(none);
   }
 
   @media (max-width: $grid-float-breakpoint-max) {
@@ -400,6 +401,10 @@
 
   .navbar-brand {
     color: $navbar-default-brand-color;
+    &:active {
+      color: $navbar-default-brand-hover-color;
+      background-color: $navbar-default-brand-hover-bg;
+    }
     @include hover-support {
       &:hover,
       &:focus {
@@ -416,7 +421,10 @@
   .navbar-nav {
     > li > a {
       color: $navbar-default-link-color;
-
+      &:active {
+        color: $navbar-default-link-hover-color;
+        background-color: $navbar-default-link-hover-bg;
+      }
       @include hover-support {
         &:hover,
         &:focus {
@@ -428,6 +436,7 @@
     > .active > a {
       &,
       &:hover,
+      &:active,
       &:focus {
         color: $navbar-default-link-active-color;
         background-color: $navbar-default-link-active-bg;
@@ -436,6 +445,7 @@
     > .disabled > a {
       &,
       &:hover,
+      &:active,
       &:focus {
         color: $navbar-default-link-disabled-color;
         background-color: $navbar-default-link-disabled-bg;
@@ -445,6 +455,9 @@
 
   .navbar-toggle {
     border-color: $navbar-default-toggle-border-color;
+    &:active {
+      background-color: $navbar-default-toggle-hover-bg;
+    }
     @include hover-support {
       &:hover,
       &:focus {
@@ -467,6 +480,7 @@
     > .open > a {
       &,
       &:hover,
+      &:active,
       &:focus {
         background-color: $navbar-default-link-active-bg;
         color: $navbar-default-link-active-color;
@@ -478,6 +492,10 @@
       .open .dropdown-menu {
         > li > a {
           color: $navbar-default-link-color;
+          &:active {
+            color: $navbar-default-link-hover-color;
+            background-color: $navbar-default-link-hover-bg;
+          }
           @include hover-support {
             &:hover,
             &:focus {
@@ -489,6 +507,7 @@
         > .active > a {
           &,
           &:hover,
+          &:active,
           &:focus {
             color: $navbar-default-link-active-color;
             background-color: $navbar-default-link-active-bg;
@@ -497,6 +516,7 @@
         > .disabled > a {
           &,
           &:hover,
+          &:active,
           &:focus {
             color: $navbar-default-link-disabled-color;
             background-color: $navbar-default-link-disabled-bg;
@@ -544,6 +564,10 @@
 
   .navbar-brand {
     color: $navbar-inverse-brand-color;
+    &:active {
+      color: $navbar-inverse-brand-hover-color;
+      background-color: $navbar-inverse-brand-hover-bg;
+    }
     @include hover-support {
       &:hover,
       &:focus {
@@ -560,6 +584,10 @@
   .navbar-nav {
     > li > a {
       color: $navbar-inverse-link-color;
+      &:active {
+        color: $navbar-inverse-link-hover-color;
+        background-color: $navbar-inverse-link-hover-bg;
+      }
       @include hover-support {
         &:hover,
         &:focus {
@@ -589,6 +617,9 @@
   // Darken the responsive nav toggle
   .navbar-toggle {
     border-color: $navbar-inverse-toggle-border-color;
+    &:active {
+      background-color: $navbar-inverse-toggle-hover-bg;
+    }
     @include hover-support {
       &:hover,
       &:focus {
@@ -627,6 +658,10 @@
         }
         > li > a {
           color: $navbar-inverse-link-color;
+          &:active {
+            color: $navbar-inverse-link-hover-color;
+            background-color: $navbar-inverse-link-hover-bg;
+          }
           @include hover-support {
             &:hover,
             &:focus {
@@ -638,6 +673,7 @@
         > .active > a {
           &,
           &:hover,
+          &:active,
           &:focus {
             color: $navbar-inverse-link-active-color;
             background-color: $navbar-inverse-link-active-bg;
@@ -646,6 +682,7 @@
         > .disabled > a {
           &,
           &:hover,
+          &:active,
           &:focus {
             color: $navbar-inverse-link-disabled-color;
             background-color: $navbar-inverse-link-disabled-bg;

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -20,10 +20,13 @@
       position: relative;
       display: block;
       padding: $nav-link-padding;
-      &:hover,
-      &:focus {
-        text-decoration: none;
-        background-color: $nav-link-hover-bg;
+
+      @include hover-support {
+        &:hover,
+        &:focus {
+          text-decoration: none;
+          background-color: $nav-link-hover-bg;
+        }
       }
     }
 
@@ -31,12 +34,14 @@
     &.disabled > a {
       color: $nav-disabled-link-color;
 
-      &:hover,
-      &:focus {
-        color: $nav-disabled-link-hover-color;
-        text-decoration: none;
-        background-color: transparent;
-        cursor: $cursor-disabled;
+      @include hover-support {
+        &:hover,
+        &:focus {
+          color: $nav-disabled-link-hover-color;
+          text-decoration: none;
+          background-color: transparent;
+          cursor: $cursor-disabled;
+        }
       }
     }
   }
@@ -86,8 +91,11 @@
       line-height: $line-height-base;
       border: 1px solid transparent;
       border-radius: $border-radius-base $border-radius-base 0 0;
-      &:hover {
-        border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
+
+      @include hover-support {
+        &:hover {
+          border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
+        }
       }
     }
 

--- a/assets/stylesheets/bootstrap/_pagination.scss
+++ b/assets/stylesheets/bootstrap/_pagination.scss
@@ -38,12 +38,14 @@
 
   > li > a,
   > li > span {
-    &:hover,
-    &:focus {
-      z-index: 2;
-      color: $pagination-hover-color;
-      background-color: $pagination-hover-bg;
-      border-color: $pagination-hover-border;
+    @include hover-support {
+      &:hover,
+      &:focus {
+        z-index: 2;
+        color: $pagination-hover-color;
+        background-color: $pagination-hover-bg;
+        border-color: $pagination-hover-border;
+      }
     }
   }
 

--- a/assets/stylesheets/bootstrap/_scaffolding.scss
+++ b/assets/stylesheets/bootstrap/_scaffolding.scss
@@ -49,10 +49,11 @@ a {
   color: $link-color;
   text-decoration: none;
 
-  &:hover,
-  &:focus {
-    color: $link-hover-color;
-    text-decoration: $link-hover-decoration;
+  @include hover-support {
+    &:hover,
+    &:focus {
+      color: $link-hover-color;
+    }
   }
 
   &:focus {

--- a/assets/stylesheets/bootstrap/_scaffolding.scss
+++ b/assets/stylesheets/bootstrap/_scaffolding.scss
@@ -53,6 +53,7 @@ a {
     &:hover,
     &:focus {
       color: $link-hover-color;
+      text-decoration: $link-hover-decoration;
     }
   }
 

--- a/assets/stylesheets/bootstrap/_tables.scss
+++ b/assets/stylesheets/bootstrap/_tables.scss
@@ -121,9 +121,11 @@ th {
 //
 // Placed here since it has to come after the potential zebra striping
 
-.table-hover {
-  > tbody > tr:hover {
-    background-color: $table-bg-hover;
+@include hover-support {
+  .table-hover {
+    > tbody > tr:hover {
+      background-color: $table-bg-hover;
+    }
   }
 }
 

--- a/assets/stylesheets/bootstrap/_theme.scss
+++ b/assets/stylesheets/bootstrap/_theme.scss
@@ -51,10 +51,12 @@
   background-repeat: repeat-x;
   border-color: darken($btn-color, 14%);
 
-  &:hover,
-  &:focus  {
-    background-color: darken($btn-color, 12%);
-    background-position: 0 -15px;
+  @include hover-support {
+    &:hover,
+    &:focus  {
+      background-color: darken($btn-color, 12%);
+      background-position: 0 -15px;
+    }
   }
 
   &:active,
@@ -110,10 +112,12 @@
 // Dropdowns
 // --------------------------------------------------
 
-.dropdown-menu > li > a:hover,
-.dropdown-menu > li > a:focus {
-  @include gradient-vertical($start-color: $dropdown-link-hover-bg, $end-color: darken($dropdown-link-hover-bg, 5%));
-  background-color: darken($dropdown-link-hover-bg, 5%);
+@include hover-support {
+  .dropdown-menu > li > a:hover,
+  .dropdown-menu > li > a:focus {
+    @include gradient-vertical($start-color: $dropdown-link-hover-bg, $end-color: darken($dropdown-link-hover-bg, 5%));
+    background-color: darken($dropdown-link-hover-bg, 5%);
+  }
 }
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,

--- a/assets/stylesheets/bootstrap/_thumbnails.scss
+++ b/assets/stylesheets/bootstrap/_thumbnails.scss
@@ -31,8 +31,12 @@
 }
 
 // Add a hover state for linked versions only
-a.thumbnail:hover,
-a.thumbnail:focus,
+@include hover-support {
+  a.thumbnail:hover,
+  a.thumbnail:focus {
+    border-color: $link-color;
+  }
+}
 a.thumbnail.active {
   border-color: $link-color;
 }

--- a/assets/stylesheets/bootstrap/mixins/_background-variant.scss
+++ b/assets/stylesheets/bootstrap/mixins/_background-variant.scss
@@ -5,8 +5,10 @@
   #{$parent} {
     background-color: $color;
   }
-  a#{$parent}:hover,
-  a#{$parent}:focus {
-    background-color: darken($color, 10%);
+  @include hover-support {
+    a#{$parent}:hover,
+    a#{$parent}:focus {
+      background-color: darken($color, 10%);
+    }
   }
 }

--- a/assets/stylesheets/bootstrap/mixins/_buttons.scss
+++ b/assets/stylesheets/bootstrap/mixins/_buttons.scss
@@ -8,16 +8,14 @@
   background-color: $background;
   border-color: $border;
 
-  &:focus,
-  &.focus {
-    color: $color;
-    background-color: darken($background, 10%);
-        border-color: darken($border, 25%);
-  }
-  &:hover {
-    color: $color;
-    background-color: darken($background, 10%);
-        border-color: darken($border, 12%);
+  @include hover-support {
+    &:hover,
+    &:focus,
+    &.focus {
+      color: $color;
+      background-color: darken($background, 10%);
+          border-color: darken($border, 12%);
+    }
   }
   &:active,
   &.active,
@@ -26,12 +24,14 @@
     background-color: darken($background, 10%);
         border-color: darken($border, 12%);
 
-    &:hover,
-    &:focus,
-    &.focus {
-      color: $color;
-      background-color: darken($background, 17%);
-          border-color: darken($border, 25%);
+    @include hover-support {
+      &:hover,
+      &:focus,
+      &.focus {
+        color: $color;
+        background-color: darken($background, 17%);
+            border-color: darken($border, 25%);
+      }
     }
   }
   &:active,

--- a/assets/stylesheets/bootstrap/mixins/_hover.scss
+++ b/assets/stylesheets/bootstrap/mixins/_hover.scss
@@ -1,0 +1,5 @@
+@mixin hover-support {
+  @media (hover: hover), (-moz-touch-enabled: 0) {
+    @content;
+  }
+}

--- a/assets/stylesheets/bootstrap/mixins/_labels.scss
+++ b/assets/stylesheets/bootstrap/mixins/_labels.scss
@@ -3,8 +3,11 @@
 @mixin label-variant($color) {
   background-color: $color;
 
-  @include hover-support {
-    &[href] {
+  &[href] {
+    &:active {
+      background-color: darken($color, 10%);
+    }
+    @include hover-support {
       &:hover,
       &:focus {
         background-color: darken($color, 10%);

--- a/assets/stylesheets/bootstrap/mixins/_labels.scss
+++ b/assets/stylesheets/bootstrap/mixins/_labels.scss
@@ -3,10 +3,12 @@
 @mixin label-variant($color) {
   background-color: $color;
 
-  &[href] {
-    &:hover,
-    &:focus {
-      background-color: darken($color, 10%);
+  @include hover-support {
+    &[href] {
+      &:hover,
+      &:focus {
+        background-color: darken($color, 10%);
+      }
     }
   }
 }

--- a/assets/stylesheets/bootstrap/mixins/_list-group.scss
+++ b/assets/stylesheets/bootstrap/mixins/_list-group.scss
@@ -16,10 +16,12 @@
       color: inherit;
     }
 
-    &:hover,
-    &:focus {
-      color: $color;
-      background-color: darken($background, 5%);
+    @include hover-support {
+      &:hover,
+      &:focus {
+        color: $color;
+        background-color: darken($background, 5%);
+      }
     }
     &.active,
     &.active:hover,

--- a/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss
+++ b/assets/stylesheets/bootstrap/mixins/_text-emphasis.scss
@@ -5,8 +5,10 @@
   #{$parent} {
     color: $color;
   }
-  a#{$parent}:hover,
-  a#{$parent}:focus {
-    color: darken($color, 10%);
+  @include hover-support {
+    a#{$parent}:hover,
+    a#{$parent}:focus {
+      color: darken($color, 10%);
+    }
   }
 }


### PR DESCRIPTION
これまでDropdown menuには、hover要素しかなかったが、これではタッチデバイスで厳密には理想的に動かない。（特にDrawerなど出っぱなしになるような場所で使われたときに、hover状態が残ってしまう）

そこでbuttonなどと同じように、タッチデバイスではhoverは無効にし、active状態を新たに定義することにします。