### PR TITLE
Upgrade ejs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "node-sass": "^3.8.0",
     "mincer": "~1.4.0",
-    "ejs": "~2.4.2"
+    "ejs": "~2.5.8"
   },
   "eyeglass": {
     "exports": "eyeglass-exports.js",


### PR DESCRIPTION
To fix #1166.

(Note that ejs has tags for 2.5.9 and for 2.6.1, but no release - that is: https://github.com/mde/ejs/releases/tag/v2.5.8 says "Latest release" at time of writing - hence my opting for 2.5.8)