### PR TITLE
[Security] Fixes for jQuery 3.5.0

### DIFF
--- a/assets/javascripts/bootstrap.js
+++ b/assets/javascripts/bootstrap.js
@@ -1505,7 +1505,7 @@ if (typeof jQuery === 'undefined') {
     var dataAttributes = this.$element.data()
 
     for (var dataAttr in dataAttributes) {
-      if (dataAttributes.hasOwnProperty(dataAttr) && $.inArray(dataAttr, DISALLOWED_ATTRIBUTES) !== -1) {
+      if (Object.prototype.hasOwnProperty.call(dataAttributes, dataAttr) && $.inArray(dataAttr, DISALLOWED_ATTRIBUTES) !== -1) {
         delete dataAttributes[dataAttr]
       }
     }

--- a/assets/javascripts/bootstrap/collapse.js
+++ b/assets/javascripts/bootstrap/collapse.js
@@ -173,7 +173,7 @@
       var data    = $this.data('bs.collapse')
       var options = $.extend({}, Collapse.DEFAULTS, $this.data(), typeof option == 'object' && option)
 
-      if (!data && options.toggle && /show|hide/.test(option)) options.toggle = false
+      if (!data && options.toggle && typeof option === 'string' && /show|hide/.test(option)) options.toggle = false
       if (!data) $this.data('bs.collapse', (data = new Collapse(this, options)))
       if (typeof option == 'string') data[option]()
     })

--- a/assets/javascripts/bootstrap/tooltip.js
+++ b/assets/javascripts/bootstrap/tooltip.js
@@ -220,7 +220,7 @@
     var dataAttributes = this.$element.data()
 
     for (var dataAttr in dataAttributes) {
-      if (dataAttributes.hasOwnProperty(dataAttr) && $.inArray(dataAttr, DISALLOWED_ATTRIBUTES) !== -1) {
+      if (Object.prototype.hasOwnProperty.call(dataAttributes, dataAttr) && $.inArray(dataAttr, DISALLOWED_ATTRIBUTES) !== -1) {
         delete dataAttributes[dataAttr]
       }
     }


### PR DESCRIPTION
* With jQuery 3.5.0, `collapse.js` produces a `Cannot convert object to primitive value` JS error that is described in detail here: https://github.com/twbs/bootstrap/issues/30553 Backport the [fix from Bootstrap 4](https://github.com/twbs/bootstrap/pull/30559/commits/d7a71f3e857a28ca5b055f3e5d28800d9235d57b) which is part of this larger PR: https://github.com/twbs/bootstrap/pull/30559
* With jQuery 3.5.0, `tooltip.js` and `bootstrap.js` are both producing the error `TypeError: dataAttributes.hasOwnProperty is not a function`.  This issue was discussed [here](https://github.com/snapappointments/bootstrap-select/issues/2430) and their method for fixing the issue was used. Update `hasOwnProperty` calls to use syntax compatible with jQuery 3.5.0

It sounds like there is not going to be a 3.5.1 fix (maybe wait until 4.0), so this allows to safely upgrade to jQuery 3.5.0 with it's security update.