### PR TITLE
Bump Sass and migrate / to math.div()

### DIFF
--- a/assets/stylesheets/bootstrap/_carousel.scss
+++ b/assets/stylesheets/bootstrap/_carousel.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 //
 // Carousel
 // --------------------------------------------------
@@ -244,16 +246,16 @@
     .icon-next {
       width: ($carousel-control-font-size * 1.5);
       height: ($carousel-control-font-size * 1.5);
-      margin-top: ($carousel-control-font-size / -2);
+      margin-top: math.div($carousel-control-font-size, -2);
       font-size: ($carousel-control-font-size * 1.5);
     }
     .glyphicon-chevron-left,
     .icon-prev {
-      margin-left: ($carousel-control-font-size / -2);
+      margin-left: math.div($carousel-control-font-size, -2);
     }
     .glyphicon-chevron-right,
     .icon-next {
-      margin-right: ($carousel-control-font-size / -2);
+      margin-right: math.div($carousel-control-font-size, -2);
     }
   }
 

--- a/assets/stylesheets/bootstrap/_code.scss
+++ b/assets/stylesheets/bootstrap/_code.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 //
 // Code (inline and block)
 // --------------------------------------------------
@@ -40,8 +42,8 @@ kbd {
 // Blocks of code
 pre {
   display: block;
-  padding: (($line-height-computed - 1) / 2);
-  margin: 0 0 ($line-height-computed / 2);
+  padding: math.div($line-height-computed - 1, 2);
+  margin: 0 0 math.div($line-height-computed, 2);
   font-size: ($font-size-base - 1); // 14px to 13px
   line-height: $line-height-base;
   color: $pre-color;

--- a/assets/stylesheets/bootstrap/_forms.scss
+++ b/assets/stylesheets/bootstrap/_forms.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 //
 // Forms
 // --------------------------------------------------
@@ -581,7 +583,7 @@ textarea.form-control {
   // Reposition the icon because it's now within a grid column and columns have
   // `position: relative;` on them. Also accounts for the grid gutter padding.
   .has-feedback .form-control-feedback {
-    right: floor(($grid-gutter-width / 2));
+    right: floor(math.div($grid-gutter-width, 2));
   }
 
   // Form group sizes

--- a/assets/stylesheets/bootstrap/_jumbotron.scss
+++ b/assets/stylesheets/bootstrap/_jumbotron.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 //
 // Jumbotron
 // --------------------------------------------------
@@ -16,7 +18,7 @@
   }
 
   p {
-    margin-bottom: ($jumbotron-padding / 2);
+    margin-bottom: math.div($jumbotron-padding, 2);
     font-size: $jumbotron-font-size;
     font-weight: 200;
   }
@@ -27,8 +29,8 @@
 
   .container &,
   .container-fluid & {
-    padding-right: ($grid-gutter-width / 2);
-    padding-left: ($grid-gutter-width / 2);
+    padding-right: math.div($grid-gutter-width, 2);
+    padding-left: math.div($grid-gutter-width, 2);
     border-radius: $border-radius-large; // Only round corners at higher resolutions if contained in a container
   }
 

--- a/assets/stylesheets/bootstrap/_navbar.scss
+++ b/assets/stylesheets/bootstrap/_navbar.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 //
 // Navbars
 // --------------------------------------------------
@@ -228,7 +230,7 @@
 // the nav the full height of the horizontal nav (above 768px).
 
 .navbar-nav {
-  margin: ($navbar-padding-vertical / 2) (-$navbar-padding-horizontal);
+  margin: math.div($navbar-padding-vertical, 2) (-$navbar-padding-horizontal);
 
   > li > a {
     padding-top: 10px;

--- a/assets/stylesheets/bootstrap/_type.scss
+++ b/assets/stylesheets/bootstrap/_type.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 //
 // Typography
 // --------------------------------------------------
@@ -25,7 +27,7 @@ h1, .h1,
 h2, .h2,
 h3, .h3 {
   margin-top: $line-height-computed;
-  margin-bottom: ($line-height-computed / 2);
+  margin-bottom: math.div($line-height-computed, 2);
 
   small,
   .small {
@@ -35,8 +37,8 @@ h3, .h3 {
 h4, .h4,
 h5, .h5,
 h6, .h6 {
-  margin-top: ($line-height-computed / 2);
-  margin-bottom: ($line-height-computed / 2);
+  margin-top: math.div($line-height-computed, 2);
+  margin-bottom: math.div($line-height-computed, 2);
 
   small,
   .small {
@@ -56,7 +58,7 @@ h6, .h6 { font-size: $font-size-h6; }
 // -------------------------
 
 p {
-  margin: 0 0 ($line-height-computed / 2);
+  margin: 0 0 math.div($line-height-computed, 2);
 }
 
 .lead {
@@ -77,7 +79,7 @@ p {
 // Ex: (12px small font / 14px base font) * 100% = about 85%
 small,
 .small {
-  font-size: floor((100% * $font-size-small / $font-size-base));
+  font-size: floor(math.div(100% * $font-size-small, $font-size-base));
 }
 
 mark,
@@ -149,7 +151,7 @@ mark,
 ul,
 ol {
   margin-top: 0;
-  margin-bottom: ($line-height-computed / 2);
+  margin-bottom: math.div($line-height-computed, 2);
   ul,
   ol {
     margin-bottom: 0;
@@ -239,7 +241,7 @@ abbr[data-original-title] {
 
 // Blockquotes
 blockquote {
-  padding: ($line-height-computed / 2) $line-height-computed;
+  padding: math.div($line-height-computed, 2) $line-height-computed;
   margin: 0 0 $line-height-computed;
   font-size: $blockquote-font-size;
   border-left: 5px solid $blockquote-border-color;

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $bootstrap-sass-asset-helper: false !default;
 //
 // Variables
@@ -365,8 +367,8 @@ $container-lg:                 $container-large-desktop !default;
 $navbar-height:                    50px !default;
 $navbar-margin-bottom:             $line-height-computed !default;
 $navbar-border-radius:             $border-radius-base !default;
-$navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;
-$navbar-padding-vertical:          (($navbar-height - $line-height-computed) / 2) !default;
+$navbar-padding-horizontal:        floor(math.div($grid-gutter-width, 2)) !default;
+$navbar-padding-vertical:          math.div($navbar-height - $line-height-computed, 2) !default;
 $navbar-collapse-max-height:       340px !default;
 
 $navbar-default-color:             #777 !default;

--- a/assets/stylesheets/bootstrap/mixins/_grid-framework.scss
+++ b/assets/stylesheets/bootstrap/mixins/_grid-framework.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Framework grid generation
 //
 // Used only by Bootstrap to generate the correct number of grid classes given
@@ -13,8 +15,8 @@
     // Prevent columns from collapsing when empty
     min-height: 1px;
     // Inner gutter via padding
-    padding-right: floor(($grid-gutter-width / 2));
-    padding-left: ceil(($grid-gutter-width / 2));
+    padding-right: floor(math.div($grid-gutter-width, 2));
+    padding-left: ceil(math.div($grid-gutter-width, 2));
   }
 }
 
@@ -33,12 +35,12 @@
 @mixin calc-grid-column($index, $class, $type) {
   @if ($type == width) and ($index > 0) {
     .col-#{$class}-#{$index} {
-      width: percentage(($index / $grid-columns));
+      width: percentage(math.div($index, $grid-columns));
     }
   }
   @if ($type == push) and ($index > 0) {
     .col-#{$class}-push-#{$index} {
-      left: percentage(($index / $grid-columns));
+      left: percentage(math.div($index, $grid-columns));
     }
   }
   @if ($type == push) and ($index == 0) {
@@ -48,7 +50,7 @@
   }
   @if ($type == pull) and ($index > 0) {
     .col-#{$class}-pull-#{$index} {
-      right: percentage(($index / $grid-columns));
+      right: percentage(math.div($index, $grid-columns));
     }
   }
   @if ($type == pull) and ($index == 0) {
@@ -58,7 +60,7 @@
   }
   @if ($type == offset) {
     .col-#{$class}-offset-#{$index} {
-      margin-left: percentage(($index / $grid-columns));
+      margin-left: percentage(math.div($index, $grid-columns));
     }
   }
 }

--- a/assets/stylesheets/bootstrap/mixins/_grid.scss
+++ b/assets/stylesheets/bootstrap/mixins/_grid.scss
@@ -1,11 +1,13 @@
+@use "sass:math";
+
 // Grid system
 //
 // Generate semantic grid columns with these mixins.
 
 // Centered container element
 @mixin container-fixed($gutter: $grid-gutter-width) {
-  padding-right: ceil(($gutter / 2));
-  padding-left: floor(($gutter / 2));
+  padding-right: ceil(math.div($gutter, 2));
+  padding-left: floor(math.div($gutter, 2));
   margin-right: auto;
   margin-left: auto;
   @include clearfix;
@@ -13,8 +15,8 @@
 
 // Creates a wrapper for a series of columns
 @mixin make-row($gutter: $grid-gutter-width) {
-  margin-right: floor(($gutter / -2));
-  margin-left: ceil(($gutter / -2));
+  margin-right: floor(math.div($gutter, -2));
+  margin-left: ceil(math.div($gutter, -2));
   @include clearfix;
 }
 
@@ -22,46 +24,46 @@
 @mixin make-xs-column($columns, $gutter: $grid-gutter-width) {
   position: relative;
   float: left;
-  width: percentage(($columns / $grid-columns));
+  width: percentage(math.div($columns, $grid-columns));
   min-height: 1px;
-  padding-right: ($gutter / 2);
-  padding-left: ($gutter / 2);
+  padding-right: math.div($gutter, 2);
+  padding-left: math.div($gutter, 2);
 }
 @mixin make-xs-column-offset($columns) {
-  margin-left: percentage(($columns / $grid-columns));
+  margin-left: percentage(math.div($columns, $grid-columns));
 }
 @mixin make-xs-column-push($columns) {
-  left: percentage(($columns / $grid-columns));
+  left: percentage(math.div($columns, $grid-columns));
 }
 @mixin make-xs-column-pull($columns) {
-  right: percentage(($columns / $grid-columns));
+  right: percentage(math.div($columns, $grid-columns));
 }
 
 // Generate the small columns
 @mixin make-sm-column($columns, $gutter: $grid-gutter-width) {
   position: relative;
   min-height: 1px;
-  padding-right: ($gutter / 2);
-  padding-left: ($gutter / 2);
+  padding-right: math.div($gutter, 2);
+  padding-left: math.div($gutter, 2);
 
   @media (min-width: $screen-sm-min) {
     float: left;
-    width: percentage(($columns / $grid-columns));
+    width: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-sm-column-offset($columns) {
   @media (min-width: $screen-sm-min) {
-    margin-left: percentage(($columns / $grid-columns));
+    margin-left: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-sm-column-push($columns) {
   @media (min-width: $screen-sm-min) {
-    left: percentage(($columns / $grid-columns));
+    left: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-sm-column-pull($columns) {
   @media (min-width: $screen-sm-min) {
-    right: percentage(($columns / $grid-columns));
+    right: percentage(math.div($columns, $grid-columns));
   }
 }
 
@@ -69,27 +71,27 @@
 @mixin make-md-column($columns, $gutter: $grid-gutter-width) {
   position: relative;
   min-height: 1px;
-  padding-right: ($gutter / 2);
-  padding-left: ($gutter / 2);
+  padding-right: math.div($gutter, 2);
+  padding-left: math.div($gutter, 2);
 
   @media (min-width: $screen-md-min) {
     float: left;
-    width: percentage(($columns / $grid-columns));
+    width: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-md-column-offset($columns) {
   @media (min-width: $screen-md-min) {
-    margin-left: percentage(($columns / $grid-columns));
+    margin-left: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-md-column-push($columns) {
   @media (min-width: $screen-md-min) {
-    left: percentage(($columns / $grid-columns));
+    left: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-md-column-pull($columns) {
   @media (min-width: $screen-md-min) {
-    right: percentage(($columns / $grid-columns));
+    right: percentage(math.div($columns, $grid-columns));
   }
 }
 
@@ -97,26 +99,26 @@
 @mixin make-lg-column($columns, $gutter: $grid-gutter-width) {
   position: relative;
   min-height: 1px;
-  padding-right: ($gutter / 2);
-  padding-left: ($gutter / 2);
+  padding-right: math.div($gutter, 2);
+  padding-left: math.div($gutter, 2);
 
   @media (min-width: $screen-lg-min) {
     float: left;
-    width: percentage(($columns / $grid-columns));
+    width: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-lg-column-offset($columns) {
   @media (min-width: $screen-lg-min) {
-    margin-left: percentage(($columns / $grid-columns));
+    margin-left: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-lg-column-push($columns) {
   @media (min-width: $screen-lg-min) {
-    left: percentage(($columns / $grid-columns));
+    left: percentage(math.div($columns, $grid-columns));
   }
 }
 @mixin make-lg-column-pull($columns) {
   @media (min-width: $screen-lg-min) {
-    right: percentage(($columns / $grid-columns));
+    right: percentage(math.div($columns, $grid-columns));
   }
 }

--- a/assets/stylesheets/bootstrap/mixins/_nav-vertical-align.scss
+++ b/assets/stylesheets/bootstrap/mixins/_nav-vertical-align.scss
@@ -1,9 +1,11 @@
+@use "sass:math";
+
 // Navbar vertical align
 //
 // Vertically center elements in the navbar.
 // Example: an element has a height of 30px, so write out `.navbar-vertical-align(30px);` to calculate the appropriate top margin.
 
 @mixin navbar-vertical-align($element-height) {
-  margin-top: (($navbar-height - $element-height) / 2);
-  margin-bottom: (($navbar-height - $element-height) / 2);
+  margin-top: math.div($navbar-height - $element-height, 2);
+  margin-bottom: math.div($navbar-height - $element-height, 2);
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/twbs/bootstrap-sass/issues"
   },
   "devDependencies": {
-    "node-sass": "^4.9.3",
+    "sass": "^1.33",
     "mincer": "~1.4.0",
     "ejs": "~2.6.1"
   },


### PR DESCRIPTION
Fix for #1217: [Using `/` for division was recently deprecated in Sass.](https://sass-lang.com/documentation/breaking-changes/slash-div)

I've updated the source to use `math.div()` and moved to Dart Sass (version [1.33](https://sass-lang.com/documentation/breaking-changes/slash-div#transition-period)).